### PR TITLE
Add support for Resonance Audio Plugin

### DIFF
--- a/wwise-gdnative/SConstruct
+++ b/wwise-gdnative/SConstruct
@@ -77,7 +77,7 @@ opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'gdnative-demo/wwise/bin/', PathVariable.PathIsDirCreate))
 opts.Add(PathVariable('target_name', 'The library name.', 'WwiseGDNative', PathVariable.PathAccept))
 opts.Add(PathVariable('wwise_sdk', 'The Wwise SDK path', '', PathVariable.PathAccept))
-opts.Add(ListVariable('plugins', 'List of plugins', '', ['reflect', 'motion', 'convolution', 'soundseed_grain', 'soundseed_air_impact']))
+opts.Add(ListVariable('plugins', 'List of plugins', '', ['reflect', 'motion', 'convolution', 'soundseed_grain', 'soundseed_air_impact', 'resonanceaudio']))
 opts.Add(EnumVariable('ios_arch', 'Target iOS architecture', 'arm64', ['armv7', 'arm64']))
 opts.Add('IPHONEPATH', 'Path to iPhone toolchain', '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain')
 
@@ -150,6 +150,9 @@ if 'soundseed_grain' in env['plugins']:
 if 'soundseed_air_impact' in env['plugins']:
     wwise_plugins_library.append(['AkSoundSeedWindSource', 'AkSoundSeedImpactFX', 'AkSoundSeedWooshSource'])
 
+if 'resonanceaudio' in env['plugins']:
+    wwise_plugins_library.append('ResonanceAudioFX')
+
 print("Wwise SDK headers path: " + wwise_sdk_headers_path)
 print("Wwise SDK libs path: " + wwise_sdk_libs_path)
 
@@ -203,6 +206,8 @@ if env['platform'] == "osx":
         env.Append(CPPDEFINES=['AK_SOUNDSEED_GRAIN'])
     if 'soundseed_air_impact' in env['plugins']:
         env.Append(CPPDEFINES=['AK_SOUNDSEED_AIR_IMPACT'])
+    if 'resonanceaudio' in env['plugins']:
+        env.Append(CPPDEFINES=['RESONANCE_AUDIO'])
 
 elif env['platform'] == 'ios':
 
@@ -273,6 +278,8 @@ elif env['platform'] in ('x11', 'linux'):
         env.Append(CPPDEFINES=['AK_SOUNDSEED_GRAIN'])
     if 'soundseed_air_impact' in env['plugins']:
         env.Append(CPPDEFINES=['AK_SOUNDSEED_AIR_IMPACT'])
+    if 'resonanceaudio' in env['plugins']:
+        env.Append(CPPDEFINES=['RESONANCE_AUDIO'])
 
 elif env['platform'] == "windows":
     env['target_path'] += 'win64/'
@@ -313,6 +320,8 @@ elif env['platform'] == "windows":
         env.Append(CPPDEFINES=['AK_SOUNDSEED_GRAIN'])
     if 'soundseed_air_impact' in env['plugins']:
         env.Append(CPPDEFINES=['AK_SOUNDSEED_AIR_IMPACT'])
+    if 'resonanceaudio' in env['plugins']:
+        env.Append(CPPDEFINES=['RESONANCE_AUDIO'])
 
 if env['target'] in ('debug', 'd'):
     cpp_library += '.debug'

--- a/wwise-gdnative/gdnative-demo/addons/resonance_audio/plugin.cfg
+++ b/wwise-gdnative/gdnative-demo/addons/resonance_audio/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Resonance Audio"
+description=""
+author=""
+version=""
+script="resonance_audio.gd"

--- a/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio.gd
+++ b/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio.gd
@@ -1,0 +1,23 @@
+tool
+extends EditorPlugin
+
+const ResonanceAudioRoomGizmo = preload("res://addons/resonance_audio/resonance_audio_room_gizmo.gd")
+
+var resonance_audio_room_gizmo = ResonanceAudioRoomGizmo.new()
+
+func _enter_tree():
+	var node_image = Image.new()
+	var err = node_image.load("res://addons/wwise_custom_nodes/icon/wwise_node.png")
+	if err != OK:
+		push_error("Failed load custom nodes icon")
+		return
+	var node_icon = ImageTexture.new()
+	node_icon.create_from_image(node_image, 0)
+
+	# 3D Nodes
+	add_custom_type("ResonanceAudioRoom", "Spatial", preload("res://addons/resonance_audio/resonance_audio_room.gd"), node_icon)
+	add_spatial_gizmo_plugin(resonance_audio_room_gizmo)
+
+func _exit_tree():
+	remove_custom_type("ResonanceAudioRoom")
+	remove_spatial_gizmo_plugin(resonance_audio_room_gizmo)

--- a/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio_room.gd
+++ b/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio_room.gd
@@ -1,0 +1,74 @@
+extends Spatial
+
+enum SurfaceMaterial {
+		Transparent = 0,              #< Transparent
+		AcousticCeilingTiles = 1,     #< Acoustic ceiling tiles
+		BrickBare = 2,                #< Brick, bare
+		BrickPainted = 3,             #< Brick, painted
+		ConcreteBlockCoarse = 4,      #< Concrete block, coarse
+		ConcreteBlockPainted = 5,     #< Concrete block, painted
+		CurtainHeavy = 6,             #< Curtain, heavy
+		FiberglassInsulation = 7,     #< Fiberglass insulation
+		GlassThin = 8,                #< Glass, thin
+		GlassThick = 9,               #< Glass, thick
+		Grass = 10,                   #< Grass
+		LinoleumOnConcrete = 11,      #< Linoleum on concrete
+		Marble = 12,                  #< Marble
+		Metal = 13,                   #< Galvanized sheet metal
+		ParquetOnConcrete = 14,       #< Parquet on concrete
+		PlasterRough = 15,            #< Plaster, rough
+		PlasterSmooth = 16,           #< Plaster, smooth
+		PlywoodPanel = 17,            #< Plywood panel
+		PolishedConcreteOrTile = 18,  #< Polished concrete or tile
+		Sheetrock = 19,               #< Sheetrock
+		WaterOrIceSurface = 20,       #< Water or ice surface
+		WoodCeiling = 21,             #< Wood ceiling
+		WoodPanel = 22                #< Wood panel
+	}
+
+# Room surface material in negative x direction.
+export(SurfaceMaterial) var left_wall = SurfaceMaterial.ConcreteBlockCoarse
+
+# Room surface material in positive x direction.
+export(SurfaceMaterial) var right_wall = SurfaceMaterial.ConcreteBlockCoarse
+
+# Room surface material in negative y direction.
+export(SurfaceMaterial) var _floor = SurfaceMaterial.ParquetOnConcrete
+
+# Room surface material in positive y direction.
+export(SurfaceMaterial) var ceiling = SurfaceMaterial.PlasterRough
+
+# Room surface material in negative z direction.
+export(SurfaceMaterial) var back_wall = SurfaceMaterial.ConcreteBlockCoarse
+
+# Room surface material in positive z direction.
+export(SurfaceMaterial) var front_wall = SurfaceMaterial.ConcreteBlockCoarse
+
+# Reflectivity scalar for each surface of the room.
+export(float) var reflectivity = 1.0
+
+# Reverb gain modifier in decibels.
+export(float) var reverb_gain_db = 0.0
+
+# Reverb brightness modifier.
+export(float) var reverb_brightness = 0.0;
+
+# Reverb time modifier.
+export(float) var reverb_time = 1.0;
+
+# Size of the room (normalized with respect to scale of the game object).
+export(Vector3) var size = Vector3.ONE
+
+export(AK.BUSSES._enum) var room_effects_bus;
+
+func get_listener() -> Spatial: 
+	return get_tree().get_root().find_node("AkListener", true, false) as Spatial
+
+func _ready():
+	Wwise.update_audio_room(self, Wwise.is_listener_inside_room(self, get_listener()))
+	
+func _exit_tree():
+	Wwise.update_audio_room(self, false)
+
+func _process(delta):
+	Wwise.update_audio_room(self, Wwise.is_listener_inside_room(self, get_listener()))

--- a/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio_room_gizmo.gd
+++ b/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio_room_gizmo.gd
@@ -6,7 +6,7 @@ var verts = PoolVector3Array()
 var indices = PoolIntArray()
 
 func _init():
-	create_material("main", Color(0.7, 0.3, 0, 0.07))
+	create_material("main", Color(0.7, 0.7, 0, 0.5))
 
 func redraw(gizmo):
 	gizmo.clear()
@@ -54,7 +54,7 @@ func get_mesh(spatial:ResonanceAudioRoom):
 	arrays[Mesh.ARRAY_INDEX] = indices
 
 	var mesh = ArrayMesh.new()
-	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_LINE_LOOP, arrays)
 	return mesh
 	
 func add_indices(a, b, c, d):

--- a/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio_room_gizmo.gd
+++ b/wwise-gdnative/gdnative-demo/addons/resonance_audio/resonance_audio_room_gizmo.gd
@@ -1,0 +1,67 @@
+extends EditorSpatialGizmoPlugin
+
+const ResonanceAudioRoom = preload("res://addons/resonance_audio/resonance_audio_room.gd")
+
+var verts = PoolVector3Array()
+var indices = PoolIntArray()
+
+func _init():
+	create_material("main", Color(0.7, 0.3, 0, 0.07))
+
+func redraw(gizmo):
+	gizmo.clear()
+	var spatial = gizmo.get_spatial_node() as ResonanceAudioRoom
+	
+	if has_gizmo(spatial):
+		var mesh:ArrayMesh = get_mesh(spatial)
+		gizmo.add_mesh(mesh, false, null, get_material("main", gizmo))
+
+func get_mesh(spatial:ResonanceAudioRoom):
+	var length = (1 * spatial.size.x) * 0.5
+	var height = (1 * spatial.size.y) * 0.5
+	var width = (1 * spatial.size.y) * 0.5
+	
+	var a = Vector3(-length, height, -width)
+	var b = Vector3(length, height, -width)
+	var c = Vector3(length, -height, -width)
+	var d = Vector3(-length, -height, -width)
+	var e = Vector3(length, height, width)
+	var f = Vector3(-length, height, width)
+	var g = Vector3(-length, -height, width)
+	var h = Vector3(length, -height, width)
+	
+
+	verts = PoolVector3Array( [
+	a, b, c, d,
+	e, f, g, h,
+	f, a, d, g,
+	b, e, h, c,
+	f, e, b, a,
+	d, c, h, g,
+] )
+
+	add_indices(  0,  1,  2,  3 )
+	add_indices(  4,  5,  6,  7 )
+	add_indices(  8,  9, 10, 11 )
+	add_indices( 12, 13, 14, 15 )
+	add_indices( 16, 17, 18, 19 )
+	add_indices( 20, 21, 22, 23 )
+
+	var arrays = []
+	arrays.resize(Mesh.ARRAY_MAX)
+
+	arrays[Mesh.ARRAY_VERTEX] = verts
+	arrays[Mesh.ARRAY_INDEX] = indices
+
+	var mesh = ArrayMesh.new()
+	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+	return mesh
+	
+func add_indices(a, b, c, d):
+	indices += PoolIntArray([a,c,d,  a,b,c])
+	
+func has_gizmo(spatial):
+	return spatial is ResonanceAudioRoom
+	
+func get_name():
+	return "ResonanceAudioRoom"

--- a/wwise-gdnative/src/resonance_utils.h
+++ b/wwise-gdnative/src/resonance_utils.h
@@ -1,0 +1,124 @@
+#include <cmath>
+
+static inline void convertAmplitudeFromDb(const float& inDb, float& outAmplitude)
+{
+    outAmplitude = pow(10.0f, 0.05f * inDb);
+}
+
+static inline void scaleVector(const Vector3& inVectorA, const Vector3& inVectorB, Vector3& outVector)
+{
+    outVector.x = inVectorA.x * inVectorB.x;
+    outVector.y = inVectorA.y * inVectorB.y;
+    outVector.z = inVectorA.z * inVectorB.z;
+}
+
+static inline bool hasPoint(const AABB& bounds, const Vector3& relativePosition, const Quat& rotationInverse)
+{
+    float minX = bounds.position.x - bounds.size.x * 0.5f;
+    float maxX = bounds.position.x + bounds.size.x * 0.5f;
+    float minY = bounds.position.y - bounds.size.y * 0.5f;
+    float maxY = bounds.position.y + bounds.size.y * 0.5f;
+    float minZ = bounds.position.z - bounds.size.z * 0.5f;
+    float maxZ = bounds.position.z + bounds.size.z * 0.5f;
+
+    float x = rotationInverse.xform(relativePosition).x;
+    float y = rotationInverse.xform(relativePosition).y;
+    float z = rotationInverse.xform(relativePosition).z;
+
+    return (x > minX && x < maxX && y > minY && y < maxY && z > minZ && z < maxZ) ? true : false;
+}
+
+enum SurfaceMaterial
+{
+    Transparent = 0,
+    AcousticCeilingTiles = 1,
+    BrickBare = 2,
+    BrickPainted = 3,
+    ConcreteBlockCoarse = 4,
+    ConcreteBlockPainted = 5,
+    CurtainHeavy = 6,
+    FiberglassInsulation = 7,
+    GlassThin = 8,
+    GlassThick = 9,
+    Grass = 10,
+    LinoleumOnConcrete = 11,
+    Marble = 12,
+    Metal = 13,
+    ParquetOnConcrete = 14,
+    PlasterRough = 15,
+    PlasterSmooth = 16,
+    PlywoodPanel = 17,
+    PolishedConcreteOrTile = 18,
+    Sheetrock = 19,
+    WaterOrIceSurface = 20,
+    WoodCeiling = 21,
+    WoodPanel = 22
+};
+
+struct RoomProperties
+{
+    float positionX;
+    float positionY;
+    float positionZ;
+
+    // Rotation (quaternion) of the room in world space.
+    float rotationX;
+    float rotationY;
+    float rotationZ;
+    float rotationW;
+
+    // Size of the shoebox room in world space.
+    float dimensionsX;
+    float dimensionsY;
+    float dimensionsZ;
+
+    // Material name of each surface of the shoebox room.
+    SurfaceMaterial materialLeft;
+    SurfaceMaterial materialRight;
+    SurfaceMaterial materialBottom;
+    SurfaceMaterial materialTop;
+    SurfaceMaterial materialFront;
+    SurfaceMaterial materialBack;
+
+    // User defined uniform scaling factor for reflectivity. This parameter has no effect when set
+    // to 1.0f.
+    float reflectionScalar;
+
+    // User defined reverb tail gain multiplier. This parameter has no effect when set to 0.0f.
+    float reverbGain;
+
+    // Adjusts the reverberation time across all frequency bands. RT60 values are multiplied by this
+    // factor. Has no effect when set to 1.0f.
+    float reverbTime;
+
+    // Controls the slope of a line from the lowest to the highest RT60 values (increases high
+    // frequency RT60s when positive, decreases when negative). Has no effect when set to 0.0f.
+    float reverbBrightness;
+};
+
+static inline void getRoomProperties(const Spatial* room, RoomProperties& outRoomProperties) 
+{
+	Vector3 position = room->get_global_transform().origin;
+	Quat rotation = Quat(room->get_global_transform().basis.orthonormalized());
+	Vector3 scale;	scaleVector(room->get_scale(), static_cast<Vector3>(room->get("size")), scale);
+	outRoomProperties.positionX = position.x;
+    outRoomProperties.positionY = position.y;
+    outRoomProperties.positionZ = position.z;
+    outRoomProperties.rotationX = rotation.x;
+    outRoomProperties.rotationY = rotation.y;
+    outRoomProperties.rotationZ = rotation.z;
+    outRoomProperties.rotationW = rotation.w;
+    outRoomProperties.dimensionsX = scale.x;
+    outRoomProperties.dimensionsY = scale.y;
+    outRoomProperties.dimensionsZ = scale.z;
+    outRoomProperties.materialLeft = static_cast<SurfaceMaterial>((int)room->get("left_wall"));
+    outRoomProperties.materialRight = static_cast<SurfaceMaterial>((int)room->get("right_wall"));
+    outRoomProperties.materialBottom = static_cast<SurfaceMaterial>((int)room->get("_floor"));
+    outRoomProperties.materialTop = static_cast<SurfaceMaterial>((int)room->get("ceiling"));
+    outRoomProperties.materialFront = static_cast<SurfaceMaterial>((int)room->get("front_wall"));
+    outRoomProperties.materialBack = static_cast<SurfaceMaterial>((int)room->get("back_wall"));
+    convertAmplitudeFromDb(room->get("reverb_gain_db"), outRoomProperties.reverbGain);
+    outRoomProperties.reverbTime = (float)room->get("reverb_time");
+    outRoomProperties.reverbBrightness = (float)room->get("reverb_brightness");
+    outRoomProperties.reflectionScalar = (float)room->get("reflectivity");
+}

--- a/wwise-gdnative/src/wwise_gdnative.cpp
+++ b/wwise-gdnative/src/wwise_gdnative.cpp
@@ -25,6 +25,10 @@
 #include <AK/Plugin/AkSoundSeedWooshSourceFactory.h>
 #endif
 
+#if defined(RESONANCE_AUDIO)
+#include <AK/Plugin/ResonanceAudioFXFactory.h>
+#endif
+
 using namespace godot;
 
 CAkLock Wwise::signalDataLock;

--- a/wwise-gdnative/src/wwise_gdnative.cpp
+++ b/wwise-gdnative/src/wwise_gdnative.cpp
@@ -994,13 +994,13 @@ void Wwise::updateAudioRoom(const Spatial *room, bool enabled)
 	{
 		Spatial* currentRoom = enabledRooms[enabledRooms.size() - 1];
 		RoomProperties roomProperties;	getRoomProperties(currentRoom, roomProperties);
-		AkUniqueID roomEffectsBusId = static_cast<AkUniqueID>(currentRoom->get("room_effects_bus"));
+		AkUniqueID roomEffectsBusId = (unsigned int)currentRoom->get("room_effects_bus");
 		ERROR_CHECK(AK::SoundEngine::SendPluginCustomGameData(roomEffectsBusId, AK_INVALID_GAME_OBJECT, AkPluginType::AkPluginTypeMixer,
 												  resonanceCompanyId, roomEffectsPluginId, &roomProperties, sizeof(RoomProperties)), "Sending Resonance Audio plugin data to Wwise failed.");
 	}
 	else
 	{
-		AkUniqueID roomEffectsBusId = static_cast<AkUniqueID>(room->get("room_effects_bus"));
+		AkUniqueID roomEffectsBusId = (unsigned int)room->get("room_effects_bus");
 		ERROR_CHECK(AK::SoundEngine::SendPluginCustomGameData(roomEffectsBusId, AK_INVALID_GAME_OBJECT, AkPluginType::AkPluginTypeMixer,
 												  resonanceCompanyId, roomEffectsPluginId, nullptr, 0U), "Sending Resonance Audio plugin data to Wwise failed.");
 	}

--- a/wwise-gdnative/src/wwise_gdnative.h
+++ b/wwise-gdnative/src/wwise_gdnative.h
@@ -121,6 +121,10 @@ namespace godot
 		bool suspend(bool renderAnyway);
 		bool wakeupFromSuspend();
 
+		// Resonance Audio
+		void updateAudioRoom(const Spatial* room, bool enabled);
+		bool isListenerInsideRoom(const Spatial* room, const Spatial* listener);
+
 	private:
 		const String GODOT_WINDOWS_SETTING_POSTFIX = ".Windows";
 		const String GODOT_MAC_OSX_SETTING_POSTFIX = ".OSX";
@@ -151,6 +155,12 @@ namespace godot
 
 		ProjectSettings* projectSettings;
 		CAkDefaultIOHookBlocking lowLevelIO;
+
+		// Resonance Audio
+		Array enabledRooms;
+		AABB bounds = AABB(Vector3(0,0,0), Vector3(0,0,0));
+		const AkUInt32 resonanceCompanyId = (uint32_t) 272;
+		const AkUInt32 roomEffectsPluginId = (uint32_t) 200;
 	};
 }
 

--- a/wwise-gdnative/src/wwise_gdnative.h
+++ b/wwise-gdnative/src/wwise_gdnative.h
@@ -26,6 +26,7 @@
 #include <AkDefaultIOHookBlocking.h>
 
 #include "wwise_utils.h"
+#include <resonance_utils.h>
 
 #ifndef AK_OPTIMIZED
 #include <AK/Comm/AkCommunication.h>


### PR DESCRIPTION
This PR adds support for the Resonance Audio Plugin. Initially for Windows, Mac and Linux. Looking into testing Android and iOS later.

How does the plugin work? A getting started guide is available [here](https://resonance-audio.github.io/resonance-audio/develop/wwise/getting-started.html). It's good to learn how to set up Resonance Audio with Wwise Authoring.

In short, the plugin consists of two parts:
1) **Resonance Audio Renderer**: Wwise effect that renders spatialized sound sources binaurally. **Works out of the box in Godot without any changes to the integration.** 
2) **Resonance Audio Room Effects**: This is a mixer plugin in Wwise that simulates room acoustics for sounds in the environment. **This required new additions to the Godot integration**.

How is the Resonance Audio Room implemented in Godot? 
1) A new custom node called **Resonance Audio Room** was added to the integration (as part of an "addon" named **Resonance Audio**):

![image](https://user-images.githubusercontent.com/26153311/100553953-abdd8400-3291-11eb-89ee-3878c4c326f4.png)

This node automatically displays the room in the scene by using a custom gizmo. In the inspector on the right it's possible to choose between different room properties. The size of the room is both influenced by the scale and size properties of the node.

2) The Resonance Audio Room node calls `Wwise::updateAudioRoom`:
https://github.com/alessandrofama/wwise-godot-integration/blob/3fe457b0c44e85dbb753273bff04eb981f920fcd/wwise-gdnative/src/wwise_gdnative.cpp#L975-L1007

This function adds the room to the Array `enabledRooms` if the room should be enabled. This check is performed by `Wwise::isListenerInsideRoom`:
https://github.com/alessandrofama/wwise-godot-integration/blob/3fe457b0c44e85dbb753273bff04eb981f920fcd/wwise-gdnative/src/wwise_gdnative.cpp#L1009-L1021 

3) If the listener is inside a room, we pass the room properties of our custom node to the struct `RoomProperties` and pass that data to the Resonance Audio Plugin by calling `AK::SoundEngine::SendPluginCustomGameData`:
https://github.com/alessandrofama/wwise-godot-integration/blob/3fe457b0c44e85dbb753273bff04eb981f920fcd/wwise-gdnative/src/wwise_gdnative.cpp#L993-L1000

4) Using Resonance Audio requires recompiling the GDNative library with the compilation parameter `plugins=resonanceaudio` (SCons). The Godot addon (custom room node) can be bundled into the integration or offered as a separate download. This is to be decided.
