### PR TITLE
Added option to load init bank at startup to Project Settings

### DIFF
--- a/wwise-gdnative/gdnative-demo/wwise/wwise_settings.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/wwise_settings.gd
@@ -31,6 +31,8 @@ func _add_common_user_settings():
 				TYPE_STRING, PROPERTY_HINT_DIR, "res://wwise/GeneratedSoundBanks")
 	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "startup_language", String("English(US)"), TYPE_STRING, 
 				PROPERTY_HINT_NONE, "")
+	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "load_init_bank_at_startup", 0, TYPE_BOOL, 
+				PROPERTY_HINT_NONE, "")
 	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "callback_manager_buffer_size", 4096, TYPE_INT, 
 				PROPERTY_HINT_NONE, "")
 	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "engine_logging", 0, TYPE_BOOL, 

--- a/wwise-gdnative/src/wwise_gdnative.cpp
+++ b/wwise-gdnative/src/wwise_gdnative.cpp
@@ -225,6 +225,14 @@ void Wwise::_init()
 					"Failed to set ErrorLevel_All");
 	}
 #endif
+
+	bool loadInitBank = getPlatformProjectSetting(WWISE_COMMON_USER_SETTINGS_PATH + "load_init_bank_at_startup");
+
+	if (loadInitBank)
+	{
+		AkUInt32 initBankID = AK::SoundEngine::GetIDFromString("Init");
+		loadBankID(initBankID);
+	}
 }
 
 void Wwise::_process(const float delta)


### PR DESCRIPTION
This simple change adds a checkbox to the common Wwise project settings to automatically load the init bank at engine startup.