### PR TITLE
Add callback signals to AkEvent and AkEvent2D nodes

### DIFF
--- a/wwise-gdnative/gdnative-demo/demo-scenes/misc/callbacks_test_ak_event.tscn
+++ b/wwise-gdnative/gdnative-demo/demo-scenes/misc/callbacks_test_ak_event.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://scripts/3d/bank_init_test.gd" type="Script" id=1]
+[ext_resource path="res://scripts/misc/callbacks_ak_event_demo.gd" type="Script" id=2]
+[ext_resource path="res://scripts/3d/listener_test.gd" type="Script" id=3]
+[ext_resource path="res://wwise/runtime/nodes/ak_event.gd" type="Script" id=4]
+
+[node name="CallbacksTest" type="Spatial"]
+
+[node name="Init" type="Node" parent="."]
+script = ExtResource( 1 )
+
+[node name="Camera" type="Camera" parent="."]
+script = ExtResource( 3 )
+
+[node name="AkEvent" type="Spatial" parent="."]
+script = ExtResource( 4 )
+event = 3991942870
+trigger_on = 3
+use_callback = true
+callback_flag = 776
+
+[node name="Callbacks" type="Node" parent="."]
+script = ExtResource( 2 )
+[connection signal="duration" from="AkEvent" to="Callbacks" method="_on_AkEvent_duration"]
+[connection signal="music_sync_bar" from="AkEvent" to="Callbacks" method="_on_AkEvent_music_sync_bar"]
+[connection signal="music_sync_beat" from="AkEvent" to="Callbacks" method="_on_AkEvent_music_sync_beat"]

--- a/wwise-gdnative/gdnative-demo/demo-scenes/nodes/2d/callbacks_demo_ak_event_2d.tscn
+++ b/wwise-gdnative/gdnative-demo/demo-scenes/nodes/2d/callbacks_demo_ak_event_2d.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://demo-scenes/nodes/2d/bank_initialisation_2d.tscn" type="PackedScene" id=1]
+[ext_resource path="res://icon.png" type="Texture" id=2]
+[ext_resource path="res://wwise/runtime/nodes/ak_event_2d.gd" type="Script" id=3]
+[ext_resource path="res://wwise/runtime/nodes/ak_listener_2d.gd" type="Script" id=4]
+[ext_resource path="res://scripts/misc/callbacks_ak_event_2d_demo.gd" type="Script" id=5]
+
+[node name="Node2D" type="Node2D"]
+
+[node name="Bank Initialisation 2D" parent="." instance=ExtResource( 1 )]
+
+[node name="Music" type="Sprite" parent="."]
+position = Vector2( 770.044, 172.779 )
+texture = ExtResource( 2 )
+
+[node name="AkEvent2D" type="Node2D" parent="Music"]
+visible = false
+script = ExtResource( 3 )
+event = 1939884427
+trigger_on = 3
+use_callback = true
+callback_flag = 1032
+
+[node name="Listener" type="Sprite" parent="."]
+position = Vector2( 578.559, 173.146 )
+texture = ExtResource( 2 )
+
+[node name="AkListener2D" type="Node2D" parent="Listener"]
+script = ExtResource( 4 )
+
+[node name="Node" type="Node" parent="."]
+script = ExtResource( 5 )
+[connection signal="duration" from="Music/AkEvent2D" to="Node" method="_on_AkEvent2D_duration"]
+[connection signal="music_sync_entry" from="Music/AkEvent2D" to="Node" method="_on_AkEvent2D_music_sync_entry"]

--- a/wwise-gdnative/gdnative-demo/scripts/misc/callbacks_ak_event_2d_demo.gd
+++ b/wwise-gdnative/gdnative-demo/scripts/misc/callbacks_ak_event_2d_demo.gd
@@ -1,0 +1,7 @@
+extends Node
+
+func _on_AkEvent2D_music_sync_entry(data):
+	print(data)
+
+func _on_AkEvent2D_duration(data):
+	print(data)

--- a/wwise-gdnative/gdnative-demo/scripts/misc/callbacks_ak_event_demo.gd
+++ b/wwise-gdnative/gdnative-demo/scripts/misc/callbacks_ak_event_demo.gd
@@ -1,0 +1,11 @@
+extends Node
+
+func _on_AkEvent_music_sync_beat(data):
+	print(data)
+
+func _on_AkEvent_music_sync_bar(data):
+	pass
+	print(data)
+
+func _on_AkEvent_duration(data):
+	print(data)

--- a/wwise-gdnative/gdnative-demo/wwise/runtime/helpers/ak_game_obj.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/runtime/helpers/ak_game_obj.gd
@@ -2,6 +2,58 @@ extends Spatial
 
 var signal_prefix:String = "_on_"
 
+export(AK.EVENTS._enum) var event:int
+export(AkUtils.GameEvent) var trigger_on:int = AkUtils.GameEvent.NONE
+export(AkUtils.GameEvent) var stop_on:int = AkUtils.GameEvent.NONE
+export(int) var stop_fade_time:int = 0
+export(AkUtils.AkCurveInterpolation) var stop_interpolation_curve:int = AkUtils.AkCurveInterpolation.LINEAR
+export(bool) var is_environment_aware:bool = false;
+export(bool) var is_spatial:bool = false
+export(bool) var use_callback:bool = false
+
+export(int, FLAGS, 
+"END_OF_EVENT",
+"END_OF_DYNAMIC_SEQUENCE_ITEM",              
+"MARKER",                
+"DURATION",                 
+"SPEAKER_VOLUME_MATRIX",              
+"STARVATION",                 
+"MUSIC_PLAYLIST_SELECT",
+"MUSIC_PLAY_STARTED",
+"MUSIC_SYNC_BEAT",
+"MUSIC_SYNC_BAR",
+"MUSIC_SYNC_ENTRY",             
+"MUSIC_SYNC_EXIT",        
+"MUSIC_SYNC_GRID",         
+"MUSIC_SYNC_USER_CUE",           
+"MUSIC_SYNC_POINT",          
+"MUSIC_SYNC_ALL",         
+"MIDI_EVENT",         
+"CALLBACK_BITS",     
+"ENABLE_GET_SOURCE_PLAY_POSITION",
+"ENABLE_GET_MUSIC_PLAY_POSITION",
+"ENABLE_GET_SOURCE_STREAM_BUFFERING"                       
+) var callback_flag = 0
+
+signal end_of_event(data)
+signal end_of_dynamic_sequence_item(data)
+signal marker(data)
+signal duration(data)
+signal speaker_volume_matrix(data)
+signal starvation(data)
+signal music_playlist_select(data)
+signal music_play_started(data)
+signal music_sync_beat(data)
+signal music_sync_bar(data)
+signal music_sync_entry(data)
+signal music_sync_exit(data)
+signal music_sync_grid(data)
+signal music_sync_user_cue(data)
+signal music_sync_point(data)
+signal music_sync_all(data)
+signal midi_event(data)
+signal callback_bits(data)
+
 func register_game_object(object:Object, gameObjectName:String) -> void:
 	Wwise.register_game_obj(object, gameObjectName)
 
@@ -12,12 +64,12 @@ func get_listener() -> Spatial:
 # Instantiating a RayCast node, setting it as child of the event's node. 
 # It is used in compute_occlusion to check if there is any object between Event 
 # and Listener.
-func set_up_raycast(event:Spatial) -> RayCast:
+func set_up_raycast(_event:Spatial) -> RayCast:
 	var ray:RayCast = RayCast.new()
 	ray.enabled = true
 	ray.set_name("ray")
-	event.add_child(ray)
-	ray.set_owner(event)
+	_event.add_child(ray)
+	ray.set_owner(_event)
 	return ray
 
 # Without using Spatial Audio, Wwise uses Physics.Raycast in the Unity integration
@@ -46,77 +98,127 @@ func compute_occlusion(listener_transform:Transform, source_transform:Transform,
 # Here we are actually calling AK::SoundEngine::SetObjectObstructionAndOcclusion.
 # Since it doesn't need to be every frame, we do that based on the value defined
 # in OCCLUSION_DETECTION_INTERVAL (milliseconds)
-func set_obstruction_and_occlusion(event:Spatial, listener:Spatial, colliding_objects:Array, ray:RayCast, next_occlusion_update:int) -> void:
+func set_obstruction_and_occlusion(_event:Spatial, listener:Spatial, colliding_objects:Array, ray:RayCast, next_occlusion_update:int) -> void:
 	if OS.get_ticks_msec() >= next_occlusion_update:
 		next_occlusion_update = OS.get_ticks_msec() + AkUtils.OCCLUSION_DETECTION_INTERVAL
 		var current_occlusion:float = compute_occlusion(listener.get_global_transform(), self.get_global_transform(), colliding_objects, ray)
-		Wwise.set_obj_obstruction_and_occlusion(event.get_instance_id(), listener.get_instance_id(), 0, current_occlusion)
+		Wwise.set_obj_obstruction_and_occlusion(_event.get_instance_id(), listener.get_instance_id(), 0, current_occlusion)
 		
-func connect_signals(callback_receiver:NodePath, callback_type) -> void:
-	if callback_receiver.is_empty():
-		print("Please select a callback node")
-	else:
-		var callback_node:Node = get_node(callback_receiver)
-		match(callback_type):
+func connect_signals(callback:int) -> void:
+		match(callback):
 			AkUtils.AkCallbackType.AK_EndOfEvent:
-				Wwise.connect(AkUtils.Signals.END_OF_EVENT, callback_node, signal_prefix + AkUtils.Signals.END_OF_EVENT)
+				Wwise.connect(AkUtils.Signals.END_OF_EVENT, self, signal_prefix + AkUtils.Signals.END_OF_EVENT)
 					
 			AkUtils.AkCallbackType.AK_EndOfDynamicSequenceItem:
-				Wwise.connect(AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM, callback_node, signal_prefix + AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM)
+				Wwise.connect(AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM, self, signal_prefix + AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM)
 				
 			AkUtils.AkCallbackType.AK_Marker:
-				Wwise.connect(AkUtils.Signals.AUDIO_MARKER, callback_node, signal_prefix + AkUtils.Signals.AUDIO_MARKER)
+				Wwise.connect(AkUtils.Signals.AUDIO_MARKER, self, signal_prefix + AkUtils.Signals.AUDIO_MARKER)
 				
 			AkUtils.AkCallbackType.AK_Duration:
-				Wwise.connect(AkUtils.Signals.AUDIO_DURATION, callback_node, signal_prefix + AkUtils.Signals.AUDIO_DURATION)
+				Wwise.connect(AkUtils.Signals.AUDIO_DURATION, self, signal_prefix + AkUtils.Signals.AUDIO_DURATION)
 				
 			AkUtils.AkCallbackType.AK_SpeakerVolumeMatrix:
-				Wwise.connect(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, callback_node, signal_prefix + AkUtils.Signals.SPEAKER_VOLUME_MATRIX)
+				Wwise.connect(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, self, signal_prefix + AkUtils.Signals.SPEAKER_VOLUME_MATRIX)
 				
 			AkUtils.AkCallbackType.AK_Starvation:
-				Wwise.connect(AkUtils.Signals.AUDIO_STARVATION, callback_node, signal_prefix + AkUtils.Signals.AUDIO_STARVATION)
+				Wwise.connect(AkUtils.Signals.AUDIO_STARVATION, self, signal_prefix + AkUtils.Signals.AUDIO_STARVATION)
 				
 			AkUtils.AkCallbackType.AK_MusicPlaylistSelect:
-				Wwise.connect(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_PLAYLIST_SELECT)
+				Wwise.connect(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, self, signal_prefix + AkUtils.Signals.MUSIC_PLAYLIST_SELECT)
 				
 			AkUtils.AkCallbackType.AK_MusicPlayStarted:
-				Wwise.connect(AkUtils.Signals.MUSIC_PLAY_STARTED, callback_node, signal_prefix + AkUtils.Signals.MUSIC_PLAY_STARTED)
+				Wwise.connect(AkUtils.Signals.MUSIC_PLAY_STARTED, self, signal_prefix + AkUtils.Signals.MUSIC_PLAY_STARTED)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncBeat:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BEAT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BEAT)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BEAT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BEAT)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncBar:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BAR, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BAR)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BAR, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BAR)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncEntry:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ENTRY, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ENTRY)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ENTRY, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ENTRY)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncExit:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_EXIT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_EXIT)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_EXIT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_EXIT)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncGrid:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_GRID, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_GRID)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_GRID, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_GRID)
 				
-			AkUtils.AkCallbackType.AK_MusicSyncUser:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_USER_CUE, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_USER_CUE)
+			AkUtils.AkCallbackType.AK_MusicSyncUserCue:
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_USER_CUE, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_USER_CUE)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncPoint:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_POINT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_POINT)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_POINT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_POINT)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncAll:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ALL, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ALL)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ALL, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ALL)
 					
 			AkUtils.AkCallbackType.AK_MIDIEvent:
-				Wwise.connect(AkUtils.Signals.MIDI_EVENT, callback_node, signal_prefix + AkUtils.Signals.MIDI_EVENT)
+				Wwise.connect(AkUtils.Signals.MIDI_EVENT, self, signal_prefix + AkUtils.Signals.MIDI_EVENT)
 				
 			AkUtils.AkCallbackType.AK_CallbackBits:
-				Wwise.connect(AkUtils.Signals.CALLBACK_BITS, callback_node, signal_prefix + AkUtils.Signals.CALLBACK_BITS)
+				Wwise.connect(AkUtils.Signals.CALLBACK_BITS, self, signal_prefix + AkUtils.Signals.CALLBACK_BITS)
 				
 			AkUtils.AkCallbackType.AK_EnableGetSourcePlayPosition:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION, callback_node, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION)
+				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION, self, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION)
 				
 			AkUtils.AkCallbackType.AK_EnableGetMusicPlayPosition:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION, callback_node, signal_prefix + AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION)
+				Wwise.connect(AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION, self, signal_prefix + AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION)
 				
 			AkUtils.AkCallbackType.AK_EnableGetSourceStreamBuffering:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING, callback_node, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING)
+				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING, self, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING)
+
+func _on_end_of_event(data):
+	emit_signal("end_of_event", data)
+
+func _on_end_of_dynamic_sequence_item(data):
+	emit_signal("end_of_dynamic_sequence_item", data)
+	
+func _on_audio_marker(data):
+	emit_signal("marker", data)
+
+func _on_audio_duration(data):
+	emit_signal("duration", data)
+	
+func _on_speaker_volume_matrix(data):
+	emit_signal("speaker_volume_matrix", data)
+
+func _on_audio_starvation(data):
+	emit_signal("starvation", data)
+	
+func _on_music_playlist_select(data):
+	emit_signal("music_playlist_select", data)
+
+func _on_music_play_started(data):
+	emit_signal("music_play_started", data)
+	
+func _on_music_sync_beat(data):
+	emit_signal("music_sync_beat", data)
+
+func _on_music_sync_bar(data):
+	emit_signal("music_sync_bar", data)
+	
+func _on_music_sync_entry(data):
+	emit_signal("music_sync_entry", data)
+
+func _on_music_sync_exit(data):
+	emit_signal("music_sync_exit", data)
+	
+func _on_music_sync_grid(data):
+	emit_signal("music_sync_grid", data)
+
+func _on_music_sync_user_cue(data):
+	emit_signal("music_sync_user_cue", data)
+	
+func _on_music_sync_point(data):
+	emit_signal("music_sync_point", data)
+
+func _on_music_sync_all(data):
+	emit_signal("music_sync_all", data)
+	
+func _on_midi_event(data):
+	emit_signal("midi_event", data)
+
+func _on_callback_bits(data):
+	emit_signal("callback_bits", data)

--- a/wwise-gdnative/gdnative-demo/wwise/runtime/helpers/ak_game_obj_2d.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/runtime/helpers/ak_game_obj_2d.gd
@@ -2,74 +2,174 @@ extends Node2D
 
 var signal_prefix:String = "_on_"
 
+export(AK.EVENTS._enum) var event:int
+export(AkUtils.GameEvent) var trigger_on:int = AkUtils.GameEvent.NONE
+export(AkUtils.GameEvent) var stop_on:int = AkUtils.GameEvent.NONE
+export(int) var stop_fade_time:int = 0
+export (AkUtils.AkCurveInterpolation) var interpolation_mode:int = AkUtils.AkCurveInterpolation.LINEAR
+export(bool) var use_callback:bool = false
+
+export(int, FLAGS, 
+"END_OF_EVENT",
+"END_OF_DYNAMIC_SEQUENCE_ITEM",              
+"MARKER",                
+"DURATION",                 
+"SPEAKER_VOLUME_MATRIX",              
+"STARVATION",                 
+"MUSIC_PLAYLIST_SELECT",
+"MUSIC_PLAY_STARTED",
+"MUSIC_SYNC_BEAT",
+"MUSIC_SYNC_BAR",
+"MUSIC_SYNC_ENTRY",             
+"MUSIC_SYNC_EXIT",        
+"MUSIC_SYNC_GRID",         
+"MUSIC_SYNC_USER_CUE",           
+"MUSIC_SYNC_POINT",          
+"MUSIC_SYNC_ALL",         
+"MIDI_EVENT",         
+"CALLBACK_BITS",     
+"ENABLE_GET_SOURCE_PLAY_POSITION",
+"ENABLE_GET_MUSIC_PLAY_POSITION",
+"ENABLE_GET_SOURCE_STREAM_BUFFERING"                       
+) var callback_flag = 0
+
+signal end_of_event(data)
+signal end_of_dynamic_sequence_item(data)
+signal marker(data)
+signal duration(data)
+signal speaker_volume_matrix(data)
+signal starvation(data)
+signal music_playlist_select(data)
+signal music_play_started(data)
+signal music_sync_beat(data)
+signal music_sync_bar(data)
+signal music_sync_entry(data)
+signal music_sync_exit(data)
+signal music_sync_grid(data)
+signal music_sync_user_cue(data)
+signal music_sync_point(data)
+signal music_sync_all(data)
+signal midi_event(data)
+signal callback_bits(data)
+
 func register_game_object(object:Object, gameObjectName:String):
 	Wwise.register_game_obj(object, gameObjectName)
 
-func connect_signals(callback_receiver:NodePath, callback_type) -> void:
-	if callback_receiver.is_empty():
-		print("Please select a callback node")
-	else:
-		var callback_node:Node = get_node(callback_receiver)
-		match(callback_type):
+func connect_signals(callback:int) -> void:
+		match(callback):
 			AkUtils.AkCallbackType.AK_EndOfEvent:
-				Wwise.connect(AkUtils.Signals.END_OF_EVENT, callback_node, signal_prefix + AkUtils.Signals.END_OF_EVENT)
+				Wwise.connect(AkUtils.Signals.END_OF_EVENT, self, signal_prefix + AkUtils.Signals.END_OF_EVENT)
 					
 			AkUtils.AkCallbackType.AK_EndOfDynamicSequenceItem:
-				Wwise.connect(AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM, callback_node, signal_prefix + AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM)
+				Wwise.connect(AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM, self, signal_prefix + AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM)
 				
 			AkUtils.AkCallbackType.AK_Marker:
-				Wwise.connect(AkUtils.Signals.AUDIO_MARKER, callback_node, signal_prefix + AkUtils.Signals.AUDIO_MARKER)
+				Wwise.connect(AkUtils.Signals.AUDIO_MARKER, self, signal_prefix + AkUtils.Signals.AUDIO_MARKER)
 				
 			AkUtils.AkCallbackType.AK_Duration:
-				Wwise.connect(AkUtils.Signals.AUDIO_DURATION, callback_node, signal_prefix + AkUtils.Signals.AUDIO_DURATION)
+				Wwise.connect(AkUtils.Signals.AUDIO_DURATION, self, signal_prefix + AkUtils.Signals.AUDIO_DURATION)
 				
 			AkUtils.AkCallbackType.AK_SpeakerVolumeMatrix:
-				Wwise.connect(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, callback_node, signal_prefix + AkUtils.Signals.SPEAKER_VOLUME_MATRIX)
+				Wwise.connect(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, self, signal_prefix + AkUtils.Signals.SPEAKER_VOLUME_MATRIX)
 				
 			AkUtils.AkCallbackType.AK_Starvation:
-				Wwise.connect(AkUtils.Signals.AUDIO_STARVATION, callback_node, signal_prefix + AkUtils.Signals.AUDIO_STARVATION)
+				Wwise.connect(AkUtils.Signals.AUDIO_STARVATION, self, signal_prefix + AkUtils.Signals.AUDIO_STARVATION)
 				
 			AkUtils.AkCallbackType.AK_MusicPlaylistSelect:
-				Wwise.connect(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_PLAYLIST_SELECT)
+				Wwise.connect(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, self, signal_prefix + AkUtils.Signals.MUSIC_PLAYLIST_SELECT)
 				
 			AkUtils.AkCallbackType.AK_MusicPlayStarted:
-				Wwise.connect(AkUtils.Signals.MUSIC_PLAY_STARTED, callback_node, signal_prefix + AkUtils.Signals.MUSIC_PLAY_STARTED)
+				Wwise.connect(AkUtils.Signals.MUSIC_PLAY_STARTED, self, signal_prefix + AkUtils.Signals.MUSIC_PLAY_STARTED)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncBeat:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BEAT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BEAT)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BEAT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BEAT)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncBar:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BAR, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BAR)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BAR, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BAR)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncEntry:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ENTRY, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ENTRY)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ENTRY, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ENTRY)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncExit:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_EXIT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_EXIT)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_EXIT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_EXIT)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncGrid:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_GRID, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_GRID)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_GRID, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_GRID)
 				
-			AkUtils.AkCallbackType.AK_MusicSyncUser:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_USER_CUE, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_USER_CUE)
+			AkUtils.AkCallbackType.AK_MusicSyncUserCue:
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_USER_CUE, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_USER_CUE)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncPoint:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_POINT, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_POINT)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_POINT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_POINT)
 					
 			AkUtils.AkCallbackType.AK_MusicSyncAll:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ALL, callback_node, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ALL)
+				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ALL, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ALL)
 					
 			AkUtils.AkCallbackType.AK_MIDIEvent:
-				Wwise.connect(AkUtils.Signals.MIDI_EVENT, callback_node, signal_prefix + AkUtils.Signals.MIDI_EVENT)
+				Wwise.connect(AkUtils.Signals.MIDI_EVENT, self, signal_prefix + AkUtils.Signals.MIDI_EVENT)
 				
 			AkUtils.AkCallbackType.AK_CallbackBits:
-				Wwise.connect(AkUtils.Signals.CALLBACK_BITS, callback_node, signal_prefix + AkUtils.Signals.CALLBACK_BITS)
+				Wwise.connect(AkUtils.Signals.CALLBACK_BITS, self, signal_prefix + AkUtils.Signals.CALLBACK_BITS)
 				
 			AkUtils.AkCallbackType.AK_EnableGetSourcePlayPosition:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION, callback_node, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION)
+				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION, self, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION)
 				
 			AkUtils.AkCallbackType.AK_EnableGetMusicPlayPosition:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION, callback_node, signal_prefix + AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION)
+				Wwise.connect(AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION, self, signal_prefix + AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION)
 				
 			AkUtils.AkCallbackType.AK_EnableGetSourceStreamBuffering:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING, callback_node, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING)
+				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING, self, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING)
+
+func _on_end_of_event(data):
+	emit_signal("end_of_event", data)
+
+func _on_end_of_dynamic_sequence_item(data):
+	emit_signal("end_of_dynamic_sequence_item", data)
+	
+func _on_audio_marker(data):
+	emit_signal("marker", data)
+
+func _on_audio_duration(data):
+	emit_signal("duration", data)
+	
+func _on_speaker_volume_matrix(data):
+	emit_signal("speaker_volume_matrix", data)
+
+func _on_audio_starvation(data):
+	emit_signal("starvation", data)
+	
+func _on_music_playlist_select(data):
+	emit_signal("music_playlist_select", data)
+
+func _on_music_play_started(data):
+	emit_signal("music_play_started", data)
+	
+func _on_music_sync_beat(data):
+	emit_signal("music_sync_beat", data)
+
+func _on_music_sync_bar(data):
+	emit_signal("music_sync_bar", data)
+	
+func _on_music_sync_entry(data):
+	emit_signal("music_sync_entry", data)
+
+func _on_music_sync_exit(data):
+	emit_signal("music_sync_exit", data)
+	
+func _on_music_sync_grid(data):
+	emit_signal("music_sync_grid", data)
+
+func _on_music_sync_user_cue(data):
+	emit_signal("music_sync_user_cue", data)
+	
+func _on_music_sync_point(data):
+	emit_signal("music_sync_point", data)
+
+func _on_music_sync_all(data):
+	emit_signal("music_sync_all", data)
+	
+func _on_midi_event(data):
+	emit_signal("midi_event", data)
+
+func _on_callback_bits(data):
+	emit_signal("callback_bits", data)

--- a/wwise-gdnative/gdnative-demo/wwise/runtime/nodes/ak_event.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/runtime/nodes/ak_event.gd
@@ -1,23 +1,10 @@
 extends "res://wwise/runtime/helpers/ak_event_handler.gd"
 
-export(AK.EVENTS._enum) var event:int
-export(AkUtils.GameEvent) var trigger_on:int = AkUtils.GameEvent.NONE
-export(AkUtils.GameEvent) var stop_on:int = AkUtils.GameEvent.NONE
-export(int) var stop_fade_time:int = 0
-export(AkUtils.AkCurveInterpolation) var stop_interpolation_curve:int = AkUtils.AkCurveInterpolation.LINEAR
-var playing_id:int
-
-export(bool) var use_callback:bool = false
-export(AkUtils.AkCallbackType) var callback_type = AkUtils.AkCallbackType.AK_EndOfEvent
-export(NodePath) var callback_receiver:NodePath
-
-export(bool) var is_environment_aware:bool = false;
 var listener:Spatial
 var ray:RayCast
 var colliding_objects:Array = []
 var ak_environment_data
-
-export(bool) var is_spatial:bool = false
+var playing_id:int
 
 func _enter_tree():
 	if Engine.is_editor_hint():
@@ -33,7 +20,10 @@ func _ready() -> void:
 		self.set_process(true)
 		
 	if use_callback:
-		connect_signals(callback_receiver, callback_type)
+			for flag in AkUtils.AkCallbackType.values().size():
+				if (callback_flag & AkUtils.AkCallbackType.values()[flag] > 0):
+					connect_signals(AkUtils.AkCallbackType.values()[flag])
+		
 	# If is_environment_aware is checked, Wwise.set_game_obj_aux_send_values will
 	# be called. Each Event will instantiate the AkGameObjeckEnvironmentData class,
 	# this instance holds an Array with currently active environments for this
@@ -56,7 +46,7 @@ func post_event() -> void:
 	if not use_callback:
 		playing_id = Wwise.post_event_id(event, self)
 	else:
-		playing_id = Wwise.post_event_id_callback(event, callback_type, self)
+		playing_id = Wwise.post_event_id_callback(event, callback_flag, self)
 	
 func stop_event() -> void:
 	Wwise.stop_event(playing_id, stop_fade_time, stop_interpolation_curve)

--- a/wwise-gdnative/gdnative-demo/wwise/runtime/nodes/ak_event_2d.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/runtime/nodes/ak_event_2d.gd
@@ -1,23 +1,15 @@
 extends "res://wwise/runtime/helpers/ak_event_handler_2d.gd"
 
-export(AK.EVENTS._enum) var event:int
-export(AkUtils.GameEvent) var trigger_on:int = AkUtils.GameEvent.NONE
-export(AkUtils.GameEvent) var stop_on:int = AkUtils.GameEvent.NONE
-export(int) var stop_fade_time:int = 0
-export (AkUtils.AkCurveInterpolation) var interpolation_mode:int = AkUtils.AkCurveInterpolation.LINEAR
-
 var playingID:int
-
-export(bool) var use_callback:bool = false
-export(AkUtils.AkCallbackType) var callback_type = AkUtils.AkCallbackType.AK_EndOfEvent
-export(NodePath) var callback_receiver:NodePath
 
 func _enter_tree() -> void:
 	register_game_object(self, self.get_name())
 	
 func _ready() -> void:
 	if use_callback:
-		connect_signals(callback_receiver, callback_type)
+			for flag in AkUtils.AkCallbackType.values().size():
+				if (callback_flag & AkUtils.AkCallbackType.values()[flag] > 0):
+					connect_signals(AkUtils.AkCallbackType.values()[flag])
 				
 func handle_game_event(game_event:int) -> void:
 	if trigger_on == game_event:
@@ -29,7 +21,7 @@ func post_event() -> void:
 	if not use_callback:
 		playingID = Wwise.post_event_id(event, self)
 	else:
-		playingID = Wwise.post_event_id_callback(event, callback_type, self)
+		playingID = Wwise.post_event_id_callback(event, callback_flag, self)
 	
 func stop_event() -> void:
 	Wwise.stop_event(playingID, stop_fade_time, interpolation_mode)


### PR DESCRIPTION
This change adds event callback signals to AkEvent and AkEvent2D nodes. It aims at simplify the process of setting up callbacks for these two custom nodes.

Main changes:

- AkEvent and AkEvent2D nodes now display selectable checkboxes instead of an enum export. This allows the user to select multiple callbacks:

![grafik](https://user-images.githubusercontent.com/26153311/103281087-408eeb00-49d2-11eb-90b0-4af517e8ad00.png)

- Node/Signals tab of the AkEvent and AkEvent2D nodes now display the signals that can be connected to other nodes:

![grafik](https://user-images.githubusercontent.com/26153311/103281174-7633d400-49d2-11eb-9ce5-4f81254339bd.png)

If the connected nodes have a script attached, corresponding functions will be automatically created:

![grafik](https://user-images.githubusercontent.com/26153311/103281230-995e8380-49d2-11eb-87ab-0bcc575b0231.png)

- Moved exported properties of the AkEvent and AkEvent2D nodes to the "parent" ak_game_obj and ak_game_obj_2d scripts to clear things up and make the custom AkEvent nodes more readable.