### PR TITLE
Add custom blocking I/O implementation

### DIFF
--- a/wwise-gdnative/Android.mk
+++ b/wwise-gdnative/Android.mk
@@ -193,7 +193,7 @@ $(LOCAL_PATH)/../godot-cpp/include/core \
 $(LOCAL_PATH)/../godot-cpp/include/gen \
 src
 
-LOCAL_SRC_FILES := src/wwise_gdnative.cpp src/gdlibrary.cpp $(WWISESDK)/samples/SoundEngine/Android/AkDefaultIOHookBlocking.cpp $(WWISESDK)/samples/SoundEngine/Android/AkFileHelpers.cpp $(WWISESDK)/samples/SoundEngine/Common/AkFileLocationBase.cpp $(WWISESDK)/samples/SoundEngine/Common/AkFilePackage.cpp $(WWISESDK)/samples/SoundEngine/Common/AkFilePackageLUT.cpp
+LOCAL_SRC_FILES := src/wwise_gdnative.cpp src/wwise_godot_io.cpp src/gdlibrary.cpp $(WWISESDK)/samples/SoundEngine/Android/AkFileHelpers.cpp $(WWISESDK)/samples/SoundEngine/Common/AkFileLocationBase.cpp $(WWISESDK)/samples/SoundEngine/Common/AkFilePackage.cpp $(WWISESDK)/samples/SoundEngine/Common/AkFilePackageLUT.cpp
 
 ifeq ($(PM5_CONFIG),debug_android_armeabi-v7a)
   LOCAL_C_INCLUDES += $(WWISESDK)/samples/SoundEngine/Android/libzip/lib $(LOCAL_PATH)/. $(WWISESDK)/samples/SoundEngine/Common $(WWISESDK)/samples/SoundEngine/Android $(WWISESDK)/include $(WWISESDK)/samples/SoundEngine/POSIX

--- a/wwise-gdnative/src/wwise_gdnative.h
+++ b/wwise-gdnative/src/wwise_gdnative.h
@@ -24,8 +24,7 @@
 #include <AK/SoundEngine/Common/AkQueryParameters.h>
 #include <AK/SpatialAudio/Common/AkSpatialAudio.h>
 #include <AK/SoundEngine/Common/AkVirtualAcoustics.h>
-#include <AkDefaultIOHookBlocking.h>
-
+#include "wwise_godot_io.h"
 #include "wwise_utils.h"
 
 #ifndef AK_OPTIMIZED
@@ -52,7 +51,7 @@ class Wwise : public Node
 	void _notification(int notification);
 
 	bool setBasePath(const String basePath);
-	bool setCurrentLanguage(const String language);
+	void setCurrentLanguage(const String language);
 	bool loadBank(const String bankName);
 	bool loadBankID(const unsigned int bankID);
 	bool loadBankAsync(const String bankName);
@@ -155,7 +154,7 @@ class Wwise : public Node
 	static int signalCallbackDataMaxSize;
 
 	ProjectSettings* projectSettings;
-	CAkDefaultIOHookBlocking lowLevelIO;
+	CAkFileIOHandlerGodot lowLevelIO;
 };
 } // namespace godot
 

--- a/wwise-gdnative/src/wwise_godot_io.cpp
+++ b/wwise-gdnative/src/wwise_godot_io.cpp
@@ -1,0 +1,288 @@
+#include <wwise_godot_io.h>
+
+#define BLOCKING_DEVICE_NAME AKTEXT("Blocking Device")
+
+using namespace godot;
+
+CAkIOHookBlockingGodot::~CAkIOHookBlockingGodot()
+{
+	Term();
+}
+
+AKRESULT CAkIOHookBlockingGodot::Init(const AkDeviceSettings& in_deviceSettings)
+{
+	if (in_deviceSettings.uSchedulerTypeFlags != AK_SCHEDULER_BLOCKING)
+	{
+		AKASSERT(!"CAkIOHookBlockingGodot I/O hook only works with AK_SCHEDULER_BLOCKING devices");
+		return AK_Fail;
+	}
+
+	deviceID = AK::StreamMgr::CreateDevice(in_deviceSettings, this);
+	if (deviceID != AK_INVALID_DEVICE_ID)
+		return AK_Success;
+
+	return AK_Fail;
+}
+
+void CAkIOHookBlockingGodot::Term()
+{
+	if (deviceID != AK_INVALID_DEVICE_ID)
+	{
+		AK::StreamMgr::DestroyDevice(deviceID);
+		deviceID = AK_INVALID_DEVICE_ID;
+	}
+}
+
+AKRESULT CAkIOHookBlockingGodot::Open(const String& filePath, AkOpenMode in_eOpenMode, AkFileDesc& out_fileDesc)
+{
+	AKRESULT result = AK_Fail;
+
+	File::ModeFlags openMode;
+
+	switch (in_eOpenMode)
+	{
+	case AK_OpenModeRead:
+	{
+		openMode = File::ModeFlags::READ;
+
+		break;
+	}
+	case AK_OpenModeWrite:
+	{
+		openMode = File::ModeFlags::WRITE;
+
+		break;
+	}
+	case AK_OpenModeWriteOvrwr:
+	{
+		openMode = File::ModeFlags::WRITE_READ;
+
+		break;
+	}
+	case AK_OpenModeReadWrite:
+	{
+		openMode = File::ModeFlags::READ_WRITE;
+
+		break;
+	}
+	default:
+	{
+		AKASSERT(!"Unknown open mode");
+
+		break;
+	}
+	}
+
+	File* const file = File::_new();
+
+	if (file->open(filePath, openMode) == Error::OK)
+	{
+		out_fileDesc.iFileSize = static_cast<AkInt64>(file->get_len());
+		out_fileDesc.hFile = reinterpret_cast<AkFileHandle>(file);
+		out_fileDesc.uSector = 0;
+		out_fileDesc.deviceID = deviceID;
+		out_fileDesc.pCustomParam = nullptr;
+		out_fileDesc.uCustomParamSize = 0;
+
+		result = AK_Success;
+	}
+
+	return result;
+}
+
+AKRESULT CAkIOHookBlockingGodot::Read(AkFileDesc& in_fileDesc, const AkIoHeuristics& in_heuristics, void* out_pBuffer,
+									  AkIOTransferInfo& io_transferInfo)
+{
+	AKASSERT(out_pBuffer != nullptr && in_fileDesc.hFile != AkFileHandle(-1));
+
+	File* const file = reinterpret_cast<File*>(in_fileDesc.hFile);
+	int64_t const fileReadPosition = file->get_position();
+	int64_t const wantedFileReadPosition = io_transferInfo.uFilePosition;
+
+	if (fileReadPosition != wantedFileReadPosition)
+	{
+		file->seek(wantedFileReadPosition);
+	}
+
+	PoolByteArray fileBuffer = file->get_buffer(io_transferInfo.uRequestedSize);
+	int size = fileBuffer.size();
+	const uint8_t* data = fileBuffer.read().ptr();
+	memcpy(out_pBuffer, data, size * sizeof(uint8_t));
+
+	size_t const bytesRead = size;
+	AKASSERT(bytesRead == static_cast<size_t>(io_transferInfo.uRequestedSize));
+
+	return (bytesRead > 0) ? AK_Success : AK_Fail;
+}
+
+AKRESULT CAkIOHookBlockingGodot::Write(AkFileDesc& in_fileDesc, const AkIoHeuristics& in_heuristics, void* in_pData,
+									   AkIOTransferInfo& io_transferInfo)
+{
+	AKASSERT(in_pData != nullptr && in_fileDesc.hFile != AkFileHandle(-1));
+
+	File* const file = reinterpret_cast<File*>(in_fileDesc.hFile);
+	const int64_t fileWritePosition = file->get_position();
+	const int64_t wantedFileWritePosition = static_cast<long>(io_transferInfo.uFilePosition);
+
+	if (fileWritePosition != wantedFileWritePosition)
+	{
+		file->seek(wantedFileWritePosition);
+	}
+
+	int bytesLength = io_transferInfo.uRequestedSize;
+	PoolByteArray bytes;
+	bytes.resize(bytesLength);
+
+	memcpy((void*)bytes.write().ptr(), in_pData, bytesLength * sizeof(uint8_t));
+	file->store_buffer(bytes);
+	size_t bytesWritten = file->get_len();
+
+	AKASSERT(bytesWritten == static_cast<size_t>(io_transferInfo.uRequestedSize));
+
+	return (bytesWritten > 0) ? AK_Success : AK_Fail;
+}
+
+AKRESULT CAkIOHookBlockingGodot::Close(AkFileDesc& in_fileDesc)
+{
+	AKASSERT(in_fileDesc.hFile != AkFileHandle(-1));
+
+	AKRESULT result = AK_Fail;
+
+	File* const file = reinterpret_cast<File*>(in_fileDesc.hFile);
+	file->close();
+
+	if (file->get_error() == Error::OK)
+	{
+		file->free();
+		result = AK_Success;
+	}
+
+	return result;
+}
+
+AkUInt32 CAkIOHookBlockingGodot::GetBlockSize(AkFileDesc& in_fileDesc)
+{
+	return 1;
+}
+
+void CAkIOHookBlockingGodot::GetDeviceDesc(AkDeviceDesc&
+#ifndef AK_OPTIMIZED
+											   out_deviceDesc
+#endif
+)
+{
+#ifndef AK_OPTIMIZED
+	out_deviceDesc.deviceID = deviceID;
+	out_deviceDesc.bCanRead = true;
+	out_deviceDesc.bCanWrite = true;
+
+	AK_OSCHAR_TO_UTF16(out_deviceDesc.szDeviceName, BLOCKING_DEVICE_NAME, AK_MONITOR_DEVICENAME_MAXLENGTH);
+	out_deviceDesc.uStringSize = (AkUInt32)AKPLATFORM::AkUtf16StrLen(out_deviceDesc.szDeviceName) + 1;
+#endif
+}
+
+AkUInt32 CAkIOHookBlockingGodot::GetDeviceData()
+{
+	return 1;
+}
+
+CAkFileIOHandlerGodot::CAkFileIOHandlerGodot() : asyncOpen(false)
+{
+}
+
+AKRESULT CAkFileIOHandlerGodot::Init(const AkDeviceSettings& in_deviceSettings)
+{
+	if (!AK::StreamMgr::GetFileLocationResolver())
+	{
+		AK::StreamMgr::SetFileLocationResolver(this);
+	}
+
+	if (!blockingDevice.Init(in_deviceSettings))
+	{
+		return AK_Fail;
+	}
+	return AK_Success;
+}
+
+void CAkFileIOHandlerGodot::Term()
+{
+	if (AK::StreamMgr::GetFileLocationResolver() == this)
+	{
+		AK::StreamMgr::SetFileLocationResolver(nullptr);
+	}
+
+	blockingDevice.Term();
+}
+
+AKRESULT CAkFileIOHandlerGodot::Open(const AkOSChar* in_pszFileName, AkOpenMode in_eOpenMode,
+									 AkFileSystemFlags* in_pFlags, bool& io_bSyncOpen, AkFileDesc& out_fileDesc)
+{
+	AKRESULT result = AK_Fail;
+
+	if (io_bSyncOpen || !asyncOpen)
+	{
+		io_bSyncOpen = true;
+		char* fileName;
+		CONVERT_OSCHAR_TO_CHAR(in_pszFileName, fileName);
+		String finalFilePath = banksPath;
+
+		if (in_pFlags && in_eOpenMode == AK_OpenModeRead)
+		{
+			if (in_pFlags->uCompanyID == AKCOMPANYID_AUDIOKINETIC && in_pFlags->uCodecID == AKCODECID_BANK &&
+				in_pFlags->bIsLanguageSpecific)
+			{
+				finalFilePath = finalFilePath + languageFolder + "/";
+			}
+		}
+
+		finalFilePath = finalFilePath + fileName;
+
+		if (blockingDevice.Open(finalFilePath, in_eOpenMode, out_fileDesc) == AK_Success)
+		{
+			result = AK_Success;
+		}
+	}
+	return result;
+}
+
+AKRESULT CAkFileIOHandlerGodot::Open(AkFileID in_fileID, AkOpenMode in_eOpenMode, AkFileSystemFlags* in_pFlags,
+									 bool& io_bSyncOpen, AkFileDesc& out_fileDesc)
+{
+	AKRESULT result = AK_Fail;
+
+	if (in_pFlags != nullptr && (io_bSyncOpen || !asyncOpen))
+	{
+		io_bSyncOpen = true;
+
+		String finalFilePath = banksPath;
+
+		if (in_pFlags && in_eOpenMode == AK_OpenModeRead)
+		{
+			if (in_pFlags->uCompanyID == AKCOMPANYID_AUDIOKINETIC && in_pFlags->uCodecID == AKCODECID_BANK &&
+				in_pFlags->bIsLanguageSpecific)
+			{
+				finalFilePath = finalFilePath + languageFolder + "/";
+			}
+		}
+
+		String fileNameFormat = in_pFlags->uCodecID == AKCODECID_BANK ? ".bnk" : ".wem";
+		const String fileName = String::num_int64(static_cast<int unsigned>(in_fileID)) + fileNameFormat;
+		finalFilePath = finalFilePath + fileName;
+
+		if (blockingDevice.Open(finalFilePath, in_eOpenMode, out_fileDesc) == AK_Success)
+		{
+			result = AK_Success;
+		}
+	}
+	return result;
+}
+
+void CAkFileIOHandlerGodot::SetBanksPath(const String banksPath)
+{
+	this->banksPath = banksPath;
+}
+
+void CAkFileIOHandlerGodot::SetLanguageFolder(const String languageFolder)
+{
+	this->languageFolder = languageFolder;
+}

--- a/wwise-gdnative/src/wwise_godot_io.h
+++ b/wwise-gdnative/src/wwise_godot_io.h
@@ -1,0 +1,65 @@
+#ifndef __WWISE_GODOT_IO_H__
+#define __WWISE_GODOT_IO_H__
+
+#include <File.hpp>
+#include <String.hpp>
+#include <AK/SoundEngine/Common/AkTypes.h>
+#include <AK/SoundEngine/Common/AkStreamMgrModule.h>
+
+namespace godot
+{
+	class CAkIOHookBlockingGodot : public AK::StreamMgr::IAkIOHookBlocking
+	{
+	public:
+		~CAkIOHookBlockingGodot() override;
+
+		AKRESULT Init(const AkDeviceSettings& in_deviceSettings);
+		void Term();
+		AkDeviceID GetDeviceID() const
+		{
+			return deviceID;
+		}
+		AKRESULT Open(const String& filePath, AkOpenMode in_eOpenMode, AkFileDesc& out_fileDesc);
+		AKRESULT Read(AkFileDesc& in_fileDesc, const AkIoHeuristics& in_heuristics, void* out_pBuffer,
+			AkIOTransferInfo& io_transferInfo) override;
+		AKRESULT Write(AkFileDesc& in_fileDesc, const AkIoHeuristics& in_heuristics, void* in_pData,
+			AkIOTransferInfo& io_transferInfo) override;
+		AKRESULT Close(AkFileDesc& in_fileDesc) override;
+		AkUInt32 GetBlockSize(AkFileDesc& in_fileDesc) override;
+		void GetDeviceDesc(AkDeviceDesc& out_deviceDesc) override;
+		AkUInt32 GetDeviceData() override;
+
+	protected:
+		AkDeviceID deviceID = AK_INVALID_DEVICE_ID;
+	};
+
+	class CAkFileIOHandlerGodot : public AK::StreamMgr::IAkFileLocationResolver
+	{
+	public:
+		CAkFileIOHandlerGodot();
+		~CAkFileIOHandlerGodot() override = default;
+
+		CAkFileIOHandlerGodot(const CAkFileIOHandlerGodot&) = delete;
+		CAkFileIOHandlerGodot& operator=(const CAkFileIOHandlerGodot&) = delete;
+
+		AKRESULT Init(const AkDeviceSettings& in_deviceSettings);
+		void Term();
+
+		AKRESULT Open(const AkOSChar* in_pszFileName, AkOpenMode in_eOpenMode, AkFileSystemFlags* in_pFlags,
+			bool& io_bSyncOpen, AkFileDesc& out_fileDesc) override;
+		AKRESULT Open(AkFileID in_fileID, AkOpenMode in_eOpenMode, AkFileSystemFlags* in_pFlags, bool& io_bSyncOpen,
+			AkFileDesc& out_fileDesc) override;
+
+		void SetBanksPath(const String banksPath);
+		void SetLanguageFolder(const String languageFolder);
+
+	private:
+		CAkIOHookBlockingGodot blockingDevice;
+		String banksPath;
+		String languageFolder;
+		bool asyncOpen;
+	};
+
+}
+
+#endif

--- a/wwise-gdnative/src/wwise_utils.h
+++ b/wwise-gdnative/src/wwise_utils.h
@@ -2,6 +2,7 @@
 #define WWISE_UTILS_H
 
 #include "AK/SoundEngine/Common/AkTypes.h"
+#include "AK/SoundEngine/Common/AkCallback.h"
 #include "File.hpp"
 
 using namespace godot;
@@ -10,18 +11,6 @@ const float INVALID_RTPC_VALUE = 1.0f;
 const unsigned int AK_MAX_ENVIRONMENTS = 4;
 const int INVALID_ROOM_ID = -1;
 const AkGameObjectID OUTDOORS_ROOM_ID = (AkGameObjectID)-4;
-
-#ifdef AK_ANDROID
-#define MAP_PATH(path) path = path.replace("res://", "");
-#elif defined(AK_WIN) || defined(AK_MAC_OS_X) || defined(AK_LINUX)
-#define MAP_PATH(path)                                                                                                 \
-	if (OS::get_singleton()->has_feature("standalone"))                                                                \
-		path = path.replace("res://", OS::get_singleton()->get_user_data_dir() + "/");                                 \
-	else                                                                                                               \
-		path = path.replace("res://", "./");
-#else
-#define MAP_PATH(path) path = path.replace("res://", "./");
-#endif
 
 enum SamplesPerFrame
 {
@@ -293,50 +282,6 @@ static inline bool FindMatchingVertex(Vector3 vertex, Dictionary vertDict, int& 
 	{
 		return false;
 	}
-}
-
-static bool CopyDirectory(String from, String to)
-{
-	Ref<Directory> dir = Directory::_new();
-	Ref<File> file = File::_new();
-
-	if (!dir->dir_exists(to))
-	{
-		dir->make_dir_recursive(to);
-	}
-
-	if (dir->open(from) == godot::Error::OK)
-	{
-		dir->list_dir_begin(true);
-		String fileName = dir->get_next();
-		while (fileName != "")
-		{
-			if (dir->file_exists(fileName))
-			{
-				if (!file->file_exists(to + "/" + fileName))
-				{
-					if (dir->current_is_dir())
-					{
-						CopyDirectory(from + "/" + fileName, to + "/" + fileName);
-					}
-					else
-					{
-						dir->copy(from + "/" + fileName, to + "/" + fileName);
-					}
-				}
-				else if (file->get_md5(from + "/" + fileName) != file->get_md5(to + "/" + fileName))
-				{
-					dir->copy(from + "/" + fileName, to + "/" + fileName);
-				}
-			}
-
-			fileName = dir->get_next();
-		}
-
-		return true;
-	}
-
-	return false;
 }
 
 #endif


### PR DESCRIPTION
This PR replaces the default blocking I/O implementation with a custom blocking I/O implementation.

## Problem

Wwise’ default blocking I/O implementation expects banks that can be opened with platform ``fopen`` methods. This works fine while working in-editor, but in exported builds files are packaged in a virtual file system that is inaccessible to Wwise. Our current workaround for this problem is copying the banks to the user data folder at the start of the engine and reading the files from there. Location of the banks need to mapped for different platforms at initialization, which can be error-prone.

## Solution

This custom blocking I/O implementation uses Godot’s ``File`` class to open and read .bnk and .wem files, bypassing the need for the workaround mentioned above. Setting the `base path` of the banks using Godot’s `res://` path will now work as expected. `.bnk` and `.wem` files still need to be added to the non-resource files export list. But at least we don’t need to check the location of the banks for every platform anymore, as Godot's `File` class should take care of that.

Currently tested on Windows, macOS and Android.