### PR TITLE
Simplify Callbacks creation and processing by using Godot's FuncRef

### DIFF
--- a/wwise-gdnative/gdnative-demo/demo-scenes/misc/callbacks_test_ak_event.tscn
+++ b/wwise-gdnative/gdnative-demo/demo-scenes/misc/callbacks_test_ak_event.tscn
@@ -18,10 +18,9 @@ script = ExtResource( 4 )
 event = 3991942870
 trigger_on = 3
 use_callback = true
-callback_flag = 776
+callback_flag = 256
 
 [node name="Callbacks" type="Node" parent="."]
 script = ExtResource( 2 )
-[connection signal="duration" from="AkEvent" to="Callbacks" method="_on_AkEvent_duration"]
-[connection signal="music_sync_bar" from="AkEvent" to="Callbacks" method="_on_AkEvent_music_sync_bar"]
+
 [connection signal="music_sync_beat" from="AkEvent" to="Callbacks" method="_on_AkEvent_music_sync_beat"]

--- a/wwise-gdnative/gdnative-demo/demo-scenes/misc/load_bank_async.tscn
+++ b/wwise-gdnative/gdnative-demo/demo-scenes/misc/load_bank_async.tscn
@@ -3,4 +3,5 @@
 [ext_resource path="res://scripts/misc/load_bank_async_test.gd" type="Script" id=1]
 
 [node name="Spatial" type="Spatial"]
+pause_mode = 2
 script = ExtResource( 1 )

--- a/wwise-gdnative/gdnative-demo/scripts/3d/callbacks_test.gd
+++ b/wwise-gdnative/gdnative-demo/scripts/3d/callbacks_test.gd
@@ -3,85 +3,17 @@ extends Node
 export(AK.EVENTS._enum) var event = AK.EVENTS.MUSIC
 export(AkUtils.AkCallbackType) var callback_type = AkUtils.AkCallbackType.AK_MusicSyncBeat
 
+var cookie:FuncRef
+
 func _ready():
-	Wwise.connect(AkUtils.Signals.AUDIO_MARKER, self, "_on_audio_marker")
-	Wwise.connect(AkUtils.Signals.END_OF_EVENT, self, "_on_end_of_event")
-	Wwise.connect(AkUtils.Signals.AUDIO_DURATION, self, "_on_audio_duration")
-	Wwise.connect(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, self, "_on_speaker_volume_matrix")
-	Wwise.connect(AkUtils.Signals.AUDIO_STARVATION, self, "_on_audio_starvation")
-	Wwise.connect(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, self, "_on_music_playlist_select")
-	Wwise.connect(AkUtils.Signals.MUSIC_PLAY_STARTED, self, "_on_music_play_started")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BEAT, self, "_on_sync_beat")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BAR, self, "_on_sync_bar")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ENTRY, self, "_on_sync_entry")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_EXIT, self, "_on_sync_exit")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_GRID, self, "_on_sync_grid")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_USER_CUE, self, "_on_sync_user_cue")
-	Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ALL, self, "_on_sync_all")
-	Wwise.connect(AkUtils.Signals.MIDI_EVENT, self, "_on_midi_event")
-	Wwise.connect(AkUtils.Signals.CALLBACK_BITS, self, "_on_callback_bits")
-	Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION, self, "_on_enable_get_source_play_position")
-	Wwise.connect(AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION, self, "_on_enable_get_music_play_position")
-	Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING, self, "_on_get_source_stream_buffering")
+	var registerResult = Wwise.register_game_obj(self, "Beat Callback Test")
+	print("Registering GameObject: ", registerResult)
 
-	var registerResult = Wwise.register_game_obj(self, "Marker test")
-	print("Registering Marker test: ", registerResult)
+	cookie = FuncRef.new() # needs to be an instance variable
+	cookie.set_instance(self) # instance in which the function should be called
+	cookie.set_function("beat_callback") # name of the function
 	
-	Wwise.post_event_id_callback(event, callback_type, self)
+	Wwise.post_event_id_callback(event, callback_type, self, cookie)
 
-func _on_end_of_event(data):
-	print("End of Event data: ", data)
-
-func _on_audio_marker(data):
-	print("Marker data: ", data)
-
-func _on_audio_duration(data):
-	print("Audio Duration data: ", data)
-
-func _on_speaker_volume_matrix(data):
-	print("Speaker Volume Matrix data: ", data)
-
-func _on_audio_starvation(data):
-	print("Audio Starvation data: ", data)
-	
-func _on_music_playlist_select(data):
-	print("Music Playlist Select data: ", data)
-	
-func _on_music_play_started(data):
-	print("Music Play Started data: ", data)
-		
-func _on_sync_beat(data):
-	print("Sync Beat data: ", data)
-	
-func _on_sync_bar(data):
-	print("Sync Bar data: ", data)
-	
-func _on_sync_entry(data):
-	print("Sync Entry data: ", data)
-	
-func _on_sync_exit(data):
-	print("Sync Exit data: ", data)
-	
-func _on_sync_grid(data):
-	print("Sync Grid data: ", data)
-	
-func _on_sync_user_cue(data):
-	print("Sync User Cue data: ", data)
-	
-func _on_sync_all(data):
-	print("Sync All data: ", data)
-
-func _on_midi_event(data):
-	print("Midi Event data: ", data.midiEvent.cc.byValue)
-
-func _on_callback_bits(data):
-	print("Callback Bits data: ", data)
-	
-func _on_enable_get_source_play_position(data):
-	print("Enable Get Source Play Position data: ", data)
-	
-func _on_enable_get_music_play_position(data):
-	print("Enable Get Music Play Position data: ", data)
-	
-func _on_get_source_stream_buffering(data):
-	print("Get Source Stream Buffering data: ", data)
+func beat_callback(data):
+	print(data)

--- a/wwise-gdnative/gdnative-demo/scripts/misc/callbacks_ak_event_demo.gd
+++ b/wwise-gdnative/gdnative-demo/scripts/misc/callbacks_ak_event_demo.gd
@@ -1,11 +1,5 @@
 extends Node
 
+
 func _on_AkEvent_music_sync_beat(data):
-	print(data)
-
-func _on_AkEvent_music_sync_bar(data):
-	pass
-	print(data)
-
-func _on_AkEvent_duration(data):
 	print(data)

--- a/wwise-gdnative/gdnative-demo/scripts/misc/load_bank_async_test.gd
+++ b/wwise-gdnative/gdnative-demo/scripts/misc/load_bank_async_test.gd
@@ -1,10 +1,15 @@
-extends Node
+extends Spatial
+
+var cookie:FuncRef 
 
 func _ready():
-	Wwise.connect(AkUtils.Signals.BANK_CALLBACK, self, "on_bank_callback")
-	Wwise.load_bank_async_id(AK.BANKS.INIT)
-	Wwise.load_bank_async_id(AK.BANKS.TESTBANK)
+	cookie = FuncRef.new()
+	cookie.set_instance(self)
+	cookie.set_function("on_bank_callback")
+	Wwise.load_bank_async_id(AK.BANKS.INIT, cookie)
+	Wwise.load_bank_async_id(AK.BANKS.TESTBANK, cookie)
 
 func on_bank_callback(data):
 	print(data)
+	
 

--- a/wwise-gdnative/gdnative-demo/wwise/runtime/helpers/ak_game_obj.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/runtime/helpers/ak_game_obj.gd
@@ -1,3 +1,4 @@
+# warning-ignore-all:UNUSED_SIGNAL
 extends Spatial
 
 var signal_prefix:String = "_on_"
@@ -35,7 +36,6 @@ export(int, FLAGS,
 "ENABLE_GET_SOURCE_STREAM_BUFFERING"                       
 ) var callback_flag = 0
 
-signal end_of_event(data)
 signal end_of_dynamic_sequence_item(data)
 signal marker(data)
 signal duration(data)
@@ -102,122 +102,60 @@ func set_obstruction_and_occlusion(_event:Spatial, listener:Spatial, colliding_o
 		next_occlusion_update = OS.get_ticks_msec() + AkUtils.OCCLUSION_DETECTION_INTERVAL
 		var current_occlusion:float = compute_occlusion(listener.get_global_transform(), self.get_global_transform(), colliding_objects, ray)
 		Wwise.set_obj_obstruction_and_occlusion(_event.get_instance_id(), listener.get_instance_id(), current_occlusion, current_occlusion)
-		
-func connect_signals(callback:int) -> void:
-		match(callback):
-			AkUtils.AkCallbackType.AK_EndOfEvent:
-				Wwise.connect(AkUtils.Signals.END_OF_EVENT, self, signal_prefix + AkUtils.Signals.END_OF_EVENT)
-					
-			AkUtils.AkCallbackType.AK_EndOfDynamicSequenceItem:
-				Wwise.connect(AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM, self, signal_prefix + AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM)
-				
-			AkUtils.AkCallbackType.AK_Marker:
-				Wwise.connect(AkUtils.Signals.AUDIO_MARKER, self, signal_prefix + AkUtils.Signals.AUDIO_MARKER)
-				
-			AkUtils.AkCallbackType.AK_Duration:
-				Wwise.connect(AkUtils.Signals.AUDIO_DURATION, self, signal_prefix + AkUtils.Signals.AUDIO_DURATION)
-				
-			AkUtils.AkCallbackType.AK_SpeakerVolumeMatrix:
-				Wwise.connect(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, self, signal_prefix + AkUtils.Signals.SPEAKER_VOLUME_MATRIX)
-				
-			AkUtils.AkCallbackType.AK_Starvation:
-				Wwise.connect(AkUtils.Signals.AUDIO_STARVATION, self, signal_prefix + AkUtils.Signals.AUDIO_STARVATION)
-				
-			AkUtils.AkCallbackType.AK_MusicPlaylistSelect:
-				Wwise.connect(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, self, signal_prefix + AkUtils.Signals.MUSIC_PLAYLIST_SELECT)
-				
-			AkUtils.AkCallbackType.AK_MusicPlayStarted:
-				Wwise.connect(AkUtils.Signals.MUSIC_PLAY_STARTED, self, signal_prefix + AkUtils.Signals.MUSIC_PLAY_STARTED)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncBeat:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BEAT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BEAT)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncBar:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_BAR, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_BAR)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncEntry:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ENTRY, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ENTRY)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncExit:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_EXIT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_EXIT)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncGrid:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_GRID, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_GRID)
-				
-			AkUtils.AkCallbackType.AK_MusicSyncUserCue:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_USER_CUE, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_USER_CUE)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncPoint:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_POINT, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_POINT)
-					
-			AkUtils.AkCallbackType.AK_MusicSyncAll:
-				Wwise.connect(AkUtils.Signals.MUSIC_SYNC_ALL, self, signal_prefix + AkUtils.Signals.MUSIC_SYNC_ALL)
-					
-			AkUtils.AkCallbackType.AK_MIDIEvent:
-				Wwise.connect(AkUtils.Signals.MIDI_EVENT, self, signal_prefix + AkUtils.Signals.MIDI_EVENT)
-				
-			AkUtils.AkCallbackType.AK_CallbackBits:
-				Wwise.connect(AkUtils.Signals.CALLBACK_BITS, self, signal_prefix + AkUtils.Signals.CALLBACK_BITS)
-				
-			AkUtils.AkCallbackType.AK_EnableGetSourcePlayPosition:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION, self, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_PLAY_POSITION)
-				
-			AkUtils.AkCallbackType.AK_EnableGetMusicPlayPosition:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION, self, signal_prefix + AkUtils.Signals.ENABLE_GET_MUSIC_PLAY_POSITION)
-				
-			AkUtils.AkCallbackType.AK_EnableGetSourceStreamBuffering:
-				Wwise.connect(AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING, self, signal_prefix + AkUtils.Signals.ENABLE_GET_SOURCE_STREAM_BUFFERING)
 
-func _on_end_of_event(data):
-	emit_signal("end_of_event", data)
-
-func _on_end_of_dynamic_sequence_item(data):
-	emit_signal("end_of_dynamic_sequence_item", data)
-	
-func _on_audio_marker(data):
-	emit_signal("marker", data)
-
-func _on_audio_duration(data):
-	emit_signal("duration", data)
-	
-func _on_speaker_volume_matrix(data):
-	emit_signal("speaker_volume_matrix", data)
-
-func _on_audio_starvation(data):
-	emit_signal("starvation", data)
-	
-func _on_music_playlist_select(data):
-	emit_signal("music_playlist_select", data)
-
-func _on_music_play_started(data):
-	emit_signal("music_play_started", data)
-	
-func _on_music_sync_beat(data):
-	emit_signal("music_sync_beat", data)
-
-func _on_music_sync_bar(data):
-	emit_signal("music_sync_bar", data)
-	
-func _on_music_sync_entry(data):
-	emit_signal("music_sync_entry", data)
-
-func _on_music_sync_exit(data):
-	emit_signal("music_sync_exit", data)
-	
-func _on_music_sync_grid(data):
-	emit_signal("music_sync_grid", data)
-
-func _on_music_sync_user_cue(data):
-	emit_signal("music_sync_user_cue", data)
-	
-func _on_music_sync_point(data):
-	emit_signal("music_sync_point", data)
-
-func _on_music_sync_all(data):
-	emit_signal("music_sync_all", data)
-	
-func _on_midi_event(data):
-	emit_signal("midi_event", data)
-
-func _on_callback_bits(data):
-	emit_signal("callback_bits", data)
+			
+func callback_emitter(data):
+	match(data.callbackType):
+		AkUtils.AkCallbackType.AK_EndOfEvent:
+			emit_signal(AkUtils.Signals.END_OF_EVENT, data)
+				
+		AkUtils.AkCallbackType.AK_EndOfDynamicSequenceItem:
+			emit_signal(AkUtils.Signals.END_OF_DYNAMIC_SEQUENCE_ITEM, data)
+			
+		AkUtils.AkCallbackType.AK_Marker:
+			emit_signal(AkUtils.Signals.AUDIO_MARKER, data)
+			
+		AkUtils.AkCallbackType.AK_Duration:
+			emit_signal(AkUtils.Signals.AUDIO_DURATION, data)
+			
+		AkUtils.AkCallbackType.AK_SpeakerVolumeMatrix:
+			emit_signal(AkUtils.Signals.SPEAKER_VOLUME_MATRIX, data)
+			
+		AkUtils.AkCallbackType.AK_Starvation:
+			emit_signal(AkUtils.Signals.AUDIO_STARVATION, data)
+			
+		AkUtils.AkCallbackType.AK_MusicPlaylistSelect:
+			emit_signal(AkUtils.Signals.MUSIC_PLAYLIST_SELECT, data)
+			
+		AkUtils.AkCallbackType.AK_MusicPlayStarted:
+			emit_signal(AkUtils.Signals.MUSIC_PLAY_STARTED, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncBeat:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_BEAT, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncBar:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_BAR, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncEntry:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_ENTRY, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncExit:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_EXIT, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncGrid:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_GRID, data)
+			
+		AkUtils.AkCallbackType.AK_MusicSyncUserCue:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_USER_CUE, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncPoint:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_POINT, data)
+				
+		AkUtils.AkCallbackType.AK_MusicSyncAll:
+			emit_signal(AkUtils.Signals.MUSIC_SYNC_ALL, data)
+				
+		AkUtils.AkCallbackType.AK_MIDIEvent:
+			emit_signal(AkUtils.Signals.MIDI_EVENT, data)
+			
+		AkUtils.AkCallbackType.AK_CallbackBits:
+			emit_signal(AkUtils.Signals.CALLBACK_BITS, data)

--- a/wwise-gdnative/gdnative-demo/wwise/runtime/nodes/ak_event.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/runtime/nodes/ak_event.gd
@@ -5,6 +5,7 @@ var ray:RayCast
 var colliding_objects:Array = []
 var ak_environment_data
 var playing_id:int
+var cookie:FuncRef
 
 func _init() -> void:
 	if Engine.is_editor_hint():
@@ -18,9 +19,9 @@ func _enter_tree() -> void:
 	self.set_process(true)
 		
 	if use_callback:
-		for flag in AkUtils.AkCallbackType.values().size():
-			if (callback_flag & AkUtils.AkCallbackType.values()[flag] > 0):
-				connect_signals(AkUtils.AkCallbackType.values()[flag])
+		cookie = FuncRef.new()
+		cookie.set_function("callback_emitter")
+		cookie.set_instance(self)
 	
 	# If is_environment_aware is checked, Wwise.set_game_obj_aux_send_values will
 	# be called. Each Event will instantiate the AkGameObjeckEnvironmentData class,
@@ -44,7 +45,7 @@ func post_event() -> void:
 	if not use_callback:
 		playing_id = Wwise.post_event_id(event, self)
 	else:
-		playing_id = Wwise.post_event_id_callback(event, callback_flag, self)
+		playing_id = Wwise.post_event_id_callback(event, callback_flag, self, cookie)
 	
 func stop_event() -> void:
 	Wwise.stop_event(playing_id, stop_fade_time, stop_interpolation_curve)

--- a/wwise-gdnative/gdnative-demo/wwise/wwise_settings.gd
+++ b/wwise-gdnative/gdnative-demo/wwise/wwise_settings.gd
@@ -35,8 +35,6 @@ func _add_common_user_settings():
 				PROPERTY_HINT_NONE, "")
 	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "suspend_at_focus_loss", 1, TYPE_BOOL, 
 				PROPERTY_HINT_NONE, "")
-	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "callback_manager_buffer_size", 4096, TYPE_INT, 
-				PROPERTY_HINT_NONE, "")
 	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "engine_logging", 0, TYPE_BOOL, 
 				PROPERTY_HINT_NONE, "")
 	_add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "maximum_number_of_positioning_paths", 255, TYPE_INT, 

--- a/wwise-gdnative/src/wwise_gdnative.h
+++ b/wwise-gdnative/src/wwise_gdnative.h
@@ -2,9 +2,9 @@
 #define WWISE_GDNATIVE_H
 
 #include <Directory.hpp>
+#include <FuncRef.hpp>
 #include <Godot.hpp>
 #include <GodotGlobal.hpp>
-#include <Mutex.hpp>
 #include <Node.hpp>
 #include <OS.hpp>
 #include <Object.hpp>
@@ -55,12 +55,12 @@ class Wwise : public Node
 	void setCurrentLanguage(const String language);
 	bool loadBank(const String bankName);
 	bool loadBankID(const unsigned int bankID);
-	bool loadBankAsync(const String bankName);
-	bool loadBankAsyncID(const unsigned int bankID);
+	bool loadBankAsync(const String bankName, const Object* cookie);
+	bool loadBankAsyncID(const unsigned int bankID, const Object* cookie);
 	bool unloadBank(const String bankName);
 	bool unloadBankID(const unsigned int bankID);
-	bool unloadBankAsync(const String bankName);
-	bool unloadBankAsyncID(const unsigned int bankID);
+	bool unloadBankAsync(const String bankName, const Object* cookie);
+	bool unloadBankAsyncID(const unsigned int bankID, const Object* cookie);
 
 	bool registerListener(const Object* gameObject);
 	bool registerGameObject(const Object* gameObject, const String gameObjectName);
@@ -77,9 +77,11 @@ class Wwise : public Node
 	bool setGameObjectRadius(const Object* gameObject, const float outerRadius, const float innerRadius);
 
 	unsigned int postEvent(const String eventName, const Object* gameObject);
-	unsigned int postEventCallback(const String eventName, const unsigned int flags, const Object* gameObject);
+	unsigned int postEventCallback(const String eventName, const unsigned int flags, const Object* gameObject,
+								   const Object* cookie);
 	unsigned int postEventID(const unsigned int eventID, const Object* gameObject);
-	unsigned int postEventIDCallback(const unsigned int eventID, const unsigned int flags, const Object* gameObject);
+	unsigned int postEventIDCallback(const unsigned int eventID, const unsigned int flags, const Object* gameObject,
+									 const Object* cookie);
 	bool stopEvent(const int playingID, const int fadeTime, const int interpolation);
 
 	bool setSwitch(const String switchGroup, const String switchState, const Object* gameObject);
@@ -150,24 +152,19 @@ class Wwise : public Node
 	const String WWISE_COMMUNICATION_SETTINGS_PATH = "wwise/communication_settings/";
 
 	static void eventCallback(AkCallbackType callbackType, AkCallbackInfo* callbackInfo);
-	void emitSignals();
-
-	static void bankCallback(AkUInt32 bankID, const void* inMemoryBankPtr, AKRESULT loadResult, AkMemPoolId memPoolId);
-	void emitBankSignals();
+	static void bankCallback(AkUInt32 bankID, const void* inMemoryBankPtr, AKRESULT loadResult, void* in_pCookie);
 
 	Variant getPlatformProjectSetting(const String setting);
 
 	bool initialiseWwiseSystems();
 	bool shutdownWwiseSystems();
 
-	static CAkLock signalDataLock;
-	static std::unique_ptr<Array> signalDataArray;
-	static std::unique_ptr<Array> signalBankDataArray;
-	static int signalCallbackDataMaxSize;
+	static CAkLock callbackDataLock;
 
 	ProjectSettings* projectSettings;
 	CAkFileIOHandlerGodot lowLevelIO;
 };
+
 } // namespace godot
 
 #endif

--- a/wwise-gdnative/src/wwise_utils.h
+++ b/wwise-gdnative/src/wwise_utils.h
@@ -1,8 +1,8 @@
 #ifndef WWISE_UTILS_H
 #define WWISE_UTILS_H
 
-#include "AK/SoundEngine/Common/AkTypes.h"
 #include "AK/SoundEngine/Common/AkCallback.h"
+#include "AK/SoundEngine/Common/AkTypes.h"
 #include "File.hpp"
 
 using namespace godot;
@@ -187,57 +187,6 @@ static bool CheckError(const AKRESULT result, const String message, const char* 
 }
 
 #define ERROR_CHECK(result, message) CheckError(result, message, __FUNCTION__, __FILE__, __LINE__)
-
-static const char* WwiseCallbackToSignal(AkCallbackType callbackType)
-{
-	switch (callbackType)
-	{
-	case AK_EndOfEvent:
-		return "end_of_event";
-	case AK_EndOfDynamicSequenceItem:
-		return "end_if_dynamic_sequence_item";
-	case AK_Marker:
-		return "audio_marker";
-	case AK_Duration:
-		return "audio_duration";
-	case AK_SpeakerVolumeMatrix:
-		return "speaker_volume_matrix";
-	case AK_Starvation:
-		return "audio_starvation";
-	case AK_MusicPlaylistSelect:
-		return "music_playlist_select";
-	case AK_MusicPlayStarted:
-		return "music_play_started";
-	case AK_MusicSyncBeat:
-		return "music_sync_beat";
-	case AK_MusicSyncBar:
-		return "music_sync_bar";
-	case AK_MusicSyncEntry:
-		return "music_sync_entry";
-	case AK_MusicSyncExit:
-		return "music_sync_exit";
-	case AK_MusicSyncGrid:
-		return "music_sync_grid";
-	case AK_MusicSyncUserCue:
-		return "music_sync_user_cue";
-	case AK_MusicSyncPoint:
-		return "music_sync_point";
-	case AK_MusicSyncAll:
-		return "music_sync_all";
-	case AK_MIDIEvent:
-		return "midi_event";
-	case AK_CallbackBits:
-		return "callback_bits";
-	case AK_EnableGetSourcePlayPosition:
-		return "enable_get_source_play_position";
-	case AK_EnableGetMusicPlayPosition:
-		return "enable_get_music_play_position";
-	case AK_EnableGetSourceStreamBuffering:
-		return "enable_get_source_stream_buffering";
-	default:
-		return "Unknown callback";
-	}
-}
 
 enum class VectorType
 {


### PR DESCRIPTION
This PR aims to simplify the usage of Wwise callbacks in Godot. It removes the signal processing for callbacks from the C++ codebase and implements FuncRefs as callbacks cookies.

With [FuncRefs](https://docs.godotengine.org/en/stable/classes/class_funcref.html) we can create a reference to a function in a given object and pass the reference around, i.e. in this implementation as a cookie to the respective Wwise callbacks. We then can call the referenced function directly from the Wwise callbacks, bypassing the signal processing in ``_process()``.


``post_event_callback``, ``post_event_id_callback``, ``load_bank_async``, ``load_bank_async_id``, ``unload_bank_async`` and ``unload_bank_async_id`` now require an ``Object`` argument, which should be a ``FuncRef`` created in GDScript.

Event callback example:
```
export(AK.EVENTS._enum) var event = AK.EVENTS.MUSIC
export(AkUtils.AkCallbackType) var callback_type = AkUtils.AkCallbackType.AK_MusicSyncBeat

var cookie:FuncRef

func _ready():
	var registerResult = Wwise.register_game_obj(self, "Beat Callback Test")
	print("Registering GameObject: ", registerResult)

	cookie = FuncRef.new() # needs to be an instance variable
	cookie.set_instance(self) # instance in which the function should be called
	cookie.set_function("beat_callback") # name of the function
	
	Wwise.post_event_id_callback(event, callback_type, self, cookie)

func beat_callback(data):
	print(data)
```


Bank callback example:
```
var cookie:FuncRef 

func _ready():
	cookie = FuncRef.new()
	cookie.set_instance(self)
	cookie.set_function("on_bank_callback")
	Wwise.load_bank_async_id(AK.BANKS.INIT, cookie)
	Wwise.load_bank_async_id(AK.BANKS.TESTBANK, cookie)

func on_bank_callback(data):
	print(data)

```

The ``AkEvent`` node was modified to allow this new implementation to work with the existing signals present in the custom node. 