### PR TITLE
Add support for arm64 architecture (Apple M1)

### DIFF
--- a/.github/workflows/osx_builds.yml
+++ b/.github/workflows/osx_builds.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   macos:
     name: macOS 
-    runs-on: "macos-latest"
+    runs-on: "macos-11"
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"  
     steps:
       - name: Checkout
@@ -52,16 +52,16 @@ jobs:
       - name: Compilation
         run: |
           cd godot-cpp
-          scons platform=osx target=debug generate_bindings=yes -j4
-          scons platform=osx target=release generate_bindings=yes -j4
+          scons platform=osx target=debug generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
+          scons platform=osx target=release generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
           cd ..
           cd ${{env.PROJECT_FOLDER}}
-          scons platform=osx target=debug target_path=../${{env.TARGET_PATH}} target_name=${{env.TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j4
-          scons platform=osx target=release target_path=../${{env.TARGET_PATH}} target_name=${{env.TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j4
+          scons platform=osx target=debug target_path=../${{env.TARGET_PATH}} target_name=${{env.TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j $(sysctl -n hw.logicalcpu)
+          scons platform=osx target=release target_path=../${{env.TARGET_PATH}} target_name=${{env.TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j $(sysctl -n hw.logicalcpu)
           cd ..
           cd ${{env.WAAPI_PROJECT_FOLDER}}
-          scons platform=osx target=debug target_path=../${{env.TARGET_PATH}} target_name=${{env.WAAPI_TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j4
-          scons platform=osx target=release target_path=../${{env.TARGET_PATH}} target_name=${{env.WAAPI_TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j4
+          scons platform=osx target=debug target_path=../${{env.TARGET_PATH}} target_name=${{env.WAAPI_TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j $(sysctl -n hw.logicalcpu)
+          scons platform=osx target=release target_path=../${{env.TARGET_PATH}} target_name=${{env.WAAPI_TARGET_NAME}} wwise_sdk=../wwise_sdk/ -j $(sysctl -n hw.logicalcpu)
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v1

--- a/waapiclient-gdnative/README.md
+++ b/waapiclient-gdnative/README.md
@@ -37,3 +37,5 @@ Release
 ```
 scons target=release platform=osx wwise_sdk=/Applications/Audiokinetic/Wwise\ 2019.2.1.7250/SDK
 ```
+
+By default, this command creates an universal library that works on both the x86_64 and arm64 architectures. You can set the `macos_arch` parameter to `x86_64` or `arm64` if you want to use only one of these architectures.

--- a/waapiclient-gdnative/SConstruct
+++ b/waapiclient-gdnative/SConstruct
@@ -29,6 +29,8 @@ opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'gdnative-demo/wwise/bin/', PathVariable.PathIsDirCreate))
 opts.Add(PathVariable('target_name', 'The library name.', 'WaapiGDNative', PathVariable.PathAccept))
 opts.Add(PathVariable('wwise_sdk', 'The Wwise SDK path', '', PathVariable.PathAccept))
+opts.Add(EnumVariable('macos_arch', 'macOS architecture',
+         'universal', ['universal', 'x86_64', 'arm64']))
 
 # Local dependency paths, adapt them to your setup
 godot_headers_path = "../godot-cpp/godot-headers/"
@@ -94,18 +96,25 @@ if env['platform'] == "osx":
         env['target_path'] += 'release/'
 
     cpp_library += '.osx'
+
+    if env["macos_arch"] == "universal":
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+    else:
+        env.Append(LINKFLAGS=["-arch", env["macos_arch"]])
+        env.Append(CCFLAGS=["-arch", env["macos_arch"]])
     
     if env['target'] in ('debug', 'd'):
         env.Append(CPPDEFINES=['AK_ENABLE_ASSERTS'])
-        env.Append(CCFLAGS=['-g', '-O2', '-arch', 'x86_64'])
+        env.Append(CCFLAGS=['-g', '-O2'])
         env.Append(CXXFLAGS=['-std=c++17'])
-        env.Append(LINKFLAGS=['-arch', 'x86_64', '-framework', 'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
+        env.Append(LINKFLAGS=['-framework', 'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
     else:
         env.Append(CPPDEFINES=['AK_ENABLE_ASSERTS'])        
         env.Append(CPPDEFINES=['AK_OPTIMIZED'])
-        env.Append(CCFLAGS=['-g', '-O3', '-arch', 'x86_64'])
+        env.Append(CCFLAGS=['-g', '-O3'])
         env.Append(CXXFLAGS=['-std=c++17'])
-        env.Append(LINKFLAGS=['-arch', 'x86_64', '-framework', 'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
+        env.Append(LINKFLAGS=['-framework', 'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
 
 elif env['platform'] == "windows":
     env['target_path'] += 'win64/'
@@ -134,7 +143,14 @@ if env['target'] in ('debug', 'd'):
 else:
     cpp_library += '.release'
 
-cpp_library += '.' + str(bits)
+
+if env["platform"] == "osx":
+    if env['macos_arch'] != 'universal':
+        cpp_library += '.' + env['macos_arch']
+    else:
+        cpp_library += '.' + str(bits)
+else:
+    cpp_library += '.' + str(bits)
 
 # make sure our binding library is properly includes
 env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/'])

--- a/wwise-gdnative/README.md
+++ b/wwise-gdnative/README.md
@@ -37,6 +37,8 @@ Release
 scons target=release platform=osx wwise_sdk=/Applications/Audiokinetic/Wwise\ 2019.2.1.7250/SDK
 ```
 
+By default, this command creates an universal library that works on both the x86_64 and arm64 architectures. You can set the `macos_arch` parameter to `x86_64` or `arm64` if you want to use only one of these architectures.
+
 
 ### Linux 64-bit (Scons)
 

--- a/wwise-gdnative/SConstruct
+++ b/wwise-gdnative/SConstruct
@@ -81,6 +81,8 @@ opts.Add(ListVariable('plugins', 'List of plugins', '', ['reflect', 'motion', 'c
 opts.Add(EnumVariable('ios_arch', 'Target iOS architecture', 'arm64', ['armv7', 'arm64', 'x86_64']))
 opts.Add('IPHONEPATH', 'Path to iPhone toolchain', '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain')
 opts.Add(BoolVariable('ios_simulator', 'Target iOS Simulator', False))
+opts.Add(EnumVariable('macos_arch', 'macOS architecture',
+         'universal', ['universal', 'x86_64', 'arm64']))
 
 # Local dependency paths, adapt them to your setup
 godot_headers_path = "../godot-cpp/godot-headers/"
@@ -206,15 +208,24 @@ if env['platform'] == "osx":
 
     wwise_plugins_library.append("AkAACDecoder")
     
+    if env["macos_arch"] == "universal":
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+    else:
+        env.Append(LINKFLAGS=["-arch", env["macos_arch"]])
+        env.Append(CCFLAGS=["-arch", env["macos_arch"]])
+
     if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS=['-g', '-O2', '-arch', 'x86_64'])
+        env.Append(CCFLAGS=['-g', '-O2'])
         env.Append(CXXFLAGS=['-std=c++17'])
-        env.Append(LINKFLAGS=['-arch', 'x86_64', '-framework', 'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
+        env.Append(LINKFLAGS=['-framework',
+                   'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
     else:
         env.Append(CPPDEFINES=['AK_OPTIMIZED'])
-        env.Append(CCFLAGS=['-g', '-O3', '-arch', 'x86_64'])
+        env.Append(CCFLAGS=['-g', '-O3'])
         env.Append(CXXFLAGS=['-std=c++17'])
-        env.Append(LINKFLAGS=['-arch', 'x86_64', '-framework', 'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
+        env.Append(LINKFLAGS=['-framework',
+                   'CoreAudio', '-Wl,-undefined,dynamic_lookup'])
 
     if 'reflect' in env['plugins']:
         env.Append(CPPDEFINES=['AK_REFLECT'])
@@ -353,6 +364,11 @@ if env['platform'] == 'ios':
 
     if env['ios_simulator']:
         cpp_library += '.' + 'simulator'
+elif env["platform"] == "osx":
+    if env['macos_arch'] != 'universal':
+        cpp_library += '.' + env['macos_arch']
+    else:
+        cpp_library += '.' + str(bits)
 else:
     cpp_library += '.' + str(bits)
 

--- a/wwise-gdnative/src/wwise_gdnative.h
+++ b/wwise-gdnative/src/wwise_gdnative.h
@@ -32,7 +32,7 @@
 #include <AK/Comm/AkCommunication.h>
 #endif
 
-#if defined(AK_LINUX)
+#if defined(AK_LINUX) || defined(AK_MAC_OS_X) || defined(AK_ANDROID) || defined(AK_IOS)
 #include <memory>
 #endif
 


### PR DESCRIPTION
PR adds support for the arm64 architecture on macOS. SCons will build an universal library that targets both x86_64 and arm64 by default. Godot picks the right one under the hood. Specifying just one architecture is still possibile by passing the `macos_arch` parameter to SCons. Fixes https://github.com/alessandrofama/wwise-godot-integration/issues/43 .