### PR TITLE
Change linux build host to ubuntu 18.04

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   linux:
     name: Linux
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-18.04"
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"  
     steps:
       - name: Checkout


### PR DESCRIPTION
> Linux binaries usually won't run on distributions that are older than the distribution they were built on. If you wish to distribute binaries that work on most distributions, you should build them on an old distribution such as Ubuntu 16.04. You can use a virtual machine or a container to set up a suitable build environment.
https://docs.godotengine.org/en/stable/development/compiling/compiling_for_x11.html#building-export-templates

By building on a 20.04 host, libWwiseGDNative.so has a dependency on some math (libm) symbols at glibc version 2.29 (Ubuntu 20.04's version).
```
$ readelf -s release/libWwiseGDNative.so | grep "2\.29"
    13: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND exp@GLIBC_2.29 (10)
    18: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND log@GLIBC_2.29 (10)
    38: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND pow@GLIBC_2.29 (10)
```
This limits the use of this built shared object to distributions with this (or a newer) version of glibc.

By building on Ubuntu 18.04, we can limit this dependency to glibc 2.27 which allows the built shared object to run on more platforms. I attempted to use a 16.04 runner, however they are no longer available: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

We ran into this problem because we were using your plugin on an 18.04-like distribution.