### PR TITLE
Switch to static CRT library versions for Windows

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -2,9 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
-      - dev
   pull_request:
     branches:
       - main
@@ -29,6 +26,7 @@ jobs:
             os: "windows-2019"
             sdk-platform: windows
             scons-platform: windows
+            release-flags: use_static_cpp=true
             artifact-name: windows
 
           - name: macOS
@@ -47,14 +45,16 @@ jobs:
             os: "macos-11"
             sdk-platform: ios
             scons-platform: ios
-            flags: arch=arm64 ios_min_version=11.0
+            debug-flags: arch=arm64 ios_min_version=11.0
+            release-flags: arch=arm64 ios_min_version=11.0
             artifact-name: ios
 
           - name: Android
             os: "ubuntu-20.04"
             sdk-platform: android
             scons-platform: android
-            flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
+            debug-flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
+            release-flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             artifact-name: android-lib
     steps:
       - name: Checkout code
@@ -192,7 +192,7 @@ jobs:
         run: |
           cd addons/Wwise/native
           mkdir -p godot-cpp/bin
-          scons platform=${{ matrix.scons-platform }} target=template_debug dev_build=yes asserts=true wwise_sdk=wwise_sdk -j6 ${{ matrix.flags }}
+          scons platform=${{ matrix.scons-platform }} target=template_debug dev_build=yes asserts=true wwise_sdk=wwise_sdk -j6 ${{ matrix.debug-flags }}
           cd ../../../
 
       - name: Compile Release library
@@ -202,7 +202,7 @@ jobs:
           SCONS_CACHE_LIMIT: 7168
         run: |
           cd addons/Wwise/native
-          scons platform=${{ matrix.scons-platform }} target=template_release wwise_sdk=wwise_sdk -j6 ${{ matrix.flags }}
+          scons platform=${{ matrix.scons-platform }} target=template_release wwise_sdk=wwise_sdk -j6 ${{ matrix.release-flags }}
           cd ../../../
 
       - name: Upload libs

--- a/addons/Wwise/native/SConstruct
+++ b/addons/Wwise/native/SConstruct
@@ -70,9 +70,9 @@ wwise_soundengine_sample_path = ""
 if env["platform"] == "windows":
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/Win32/"
     if env["target"] in ("template_debug"):
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc160/Debug/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc160/Debug(StaticCRT)/lib/"
     else:
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc160/Release/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc160/Release(StaticCRT)/lib/"
 
 if env["platform"] == "macos":
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/POSIX/"
@@ -186,6 +186,7 @@ if env["platform"] == "windows":
         env.Append(LINKFLAGS=["-DEBUG"])
         if env["asserts"]:
             env.Append(CPPDEFINES=["AK_ENABLE_ASSERTS"])
+        env.Append(CCFLAGS=["/MTd"])
     else:
         env["target_path"] += "release/"
         env.Append(CPPDEFINES=["AK_OPTIMIZED"])
@@ -212,7 +213,7 @@ elif env["platform"] == "macos":
         env["target_path"] += "release/"
         env.Append(CPPDEFINES=["AK_OPTIMIZED"])
 
-    macos_install_name = "@rpath/libfmod.{}.{}.framework/libfmod.{}.{}".format(
+    macos_install_name = "@rpath/libwwise.{}.{}.framework/libwwise.{}.{}".format(
         env["platform"], env["target"], env["platform"], env["target"]
     )
 


### PR DESCRIPTION
To mitigate potential issues arising from the dependency on MSVCP140 and VCRUNTIME140, which may not be present on all Windows systems, this change adopts the use of static CRT (C Runtime Library) versions for the Wwise libraries. The godot-cpp library will also statically link the runtime libraries on Windows.