### PR TITLE
Fix Wwise IDs refresh bug after IDs Generation

### DIFF
--- a/addons/Wwise/native/src/editor/inspector_plugin/ak_inspector_plugin.cpp
+++ b/addons/Wwise/native/src/editor/inspector_plugin/ak_inspector_plugin.cpp
@@ -24,7 +24,9 @@ Dictionary AkInspectorTree::get_wwise_ids(const AkUtils::AkType ak_type)
 
 			if (!path.is_empty())
 			{
-				Ref<Script> script = ResourceLoader::get_singleton()->load(path);
+				Ref<Script> script = ResourceLoader::get_singleton()->load(
+						path, String(), ResourceLoader::CacheMode::CACHE_MODE_IGNORE);
+
 				Dictionary script_constants = script->get_script_constant_map();
 
 				String type_constant{};
@@ -345,6 +347,7 @@ void AkInspectorEditorProperty::init(const AkUtils::AkType type, const Dictionar
 void AkInspectorEditorProperty::open_popup()
 {
 	add_child(window);
+	window->tree->populate_browser("");
 
 	double editor_scale = WwiseEditorScale::get_singleton()->get_editor_scale();
 
@@ -442,7 +445,6 @@ void AkInspectorEditorProperty::_update_property()
 	close_popup();
 
 	get_edited_object()->notify_property_list_changed();
-	window->tree->populate_browser("");
 
 	updating = false;
 }

--- a/addons/Wwise/native/src/editor/waapi_picker/waapi_picker.h
+++ b/addons/Wwise/native/src/editor/waapi_picker/waapi_picker.h
@@ -14,6 +14,7 @@
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
+#include <godot_cpp/classes/resource_saver.hpp>
 #include <godot_cpp/classes/script.hpp>
 #include <godot_cpp/classes/tree.hpp>
 #include <godot_cpp/classes/tree_item.hpp>


### PR DESCRIPTION
An issue arose where Wwise IDs were not updating correctly in the custom nodes browser due to Godot's resource reloading and cache system. To rectify this problem, the commit enforces the resave of the script resource, ensuring the accurate updating of IDs and resolving the issue effectively.