### PR TITLE
Add Support for Distance Probes

### DIFF
--- a/addons/Wwise/native/doc/Wwise.xml
+++ b/addons/Wwise/native/doc/Wwise.xml
@@ -282,6 +282,26 @@
 				Note: There can be only one Spatial Audio listener registered at any given time.
 			</description>
 		</method>
+		<method name="set_distance_probe">
+			<return type="bool" />
+			<param index="0" name="listener_game_object" type="Object" />
+			<param index="1" name="probe_game_object" type="Object" />
+			<description>
+				Sets the given [param probe_game_object] to be a Distance Probe for the given
+				[param listener_game_object. This means attenuation will be calculated from the probe's
+				position, but panning and spatialization will be calculated from the listener.
+				Returns [code]true[/code] if the process succeeded. Note: Both the listener and object
+				must be registered before this will succeed.
+			</description>
+		</method>
+		<method name="reset_distance_probe">
+			<return type="bool" />
+			<param index="0" name="listener_game_object" type="Object" />
+			<description>
+				Clears the Distance Probe for the given [param listener_game_object] and reverts to using
+				the listener position for distance calculations.
+			</description>
+		</method>
 		<method name="remove_game_object_from_room">
 			<return type="bool" />
 			<param index="0" name="game_object" type="Object" />

--- a/addons/Wwise/native/src/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/wwise_gdextension.cpp
@@ -88,6 +88,8 @@ void Wwise::_bind_methods()
 	ClassDB::bind_method(D_METHOD("register_listener", "game_object"), &Wwise::register_listener);
 	ClassDB::bind_method(D_METHOD("register_game_obj", "game_object", "name"), &Wwise::register_game_obj);
 	ClassDB::bind_method(D_METHOD("unregister_game_obj", "game_object"), &Wwise::unregister_game_obj);
+	ClassDB::bind_method(D_METHOD("set_distance_probe", "listener_game_object", "probe_game_object"), &Wwise::set_distance_probe);
+	ClassDB::bind_method(D_METHOD("reset_distance_probe", "listener_game_object"), &Wwise::reset_distance_probe);
 	ClassDB::bind_method(D_METHOD("set_listeners", "emtter", "listener"), &Wwise::set_listeners);
 	ClassDB::bind_method(D_METHOD("set_random_seed", "seed"), &Wwise::set_random_seed);
 	ClassDB::bind_method(D_METHOD("set_3d_position", "game_object", "transform_3d"), &Wwise::set_3d_position);
@@ -360,6 +362,34 @@ bool Wwise::unregister_game_obj(const Object* game_object)
 	AKASSERT(game_object);
 
 	return ERROR_CHECK(AK::SoundEngine::UnregisterGameObj(static_cast<AkGameObjectID>(game_object->get_instance_id())));
+}
+
+bool Wwise::set_distance_probe(const Object* listener_game_object, const Object* probe_game_object)
+{
+	AKASSERT(listener_game_object);
+	AKASSERT(probe_game_object);
+	
+	const AkGameObjectID listener = static_cast<AkGameObjectID>(listener_game_object->get_instance_id());
+	const AkGameObjectID probe = static_cast<AkGameObjectID>(probe_game_object->get_instance_id());
+
+	if (!ERROR_CHECK(AK::SoundEngine::SetDistanceProbe(listener, probe)))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+bool Wwise::reset_distance_probe(const Object* listener_game_object)
+{
+	AKASSERT(listener_game_object);
+	const AkGameObjectID listener = static_cast<AkGameObjectID>(listener_game_object->get_instance_id());
+	if (!ERROR_CHECK(AK::SoundEngine::SetDistanceProbe(listener, AK_INVALID_GAME_OBJECT)))
+	{
+		return false;
+	}
+	
+	return true;
 }
 
 bool Wwise::set_listeners(const Object* emitter, const Object* listener)

--- a/addons/Wwise/native/src/wwise_gdextension.h
+++ b/addons/Wwise/native/src/wwise_gdextension.h
@@ -75,6 +75,9 @@ public:
 	bool register_listener(const Object* game_object);
 	bool register_game_obj(const Object* game_object, const String& game_object_name);
 	bool unregister_game_obj(const Object* game_object);
+	
+	bool set_distance_probe(const Object* listener_game_object, const Object* probe_game_object);
+	bool reset_distance_probe(const Object* listener_game_object);
 
 	bool set_listeners(const Object* emitter, const Object* listener);
 	void set_random_seed(const unsigned int seed);


### PR DESCRIPTION
### Howdy!

I recently used your implementation of Wwise in Godot for [a game jam](https://snoopy20111.itch.io/objects-in-mirror), and noticed there was no support for Distance Probes, such that 3rd person audio was sometimes a little funky. The Wwise API docs made it look pretty straightforward, so I added it myself by essentially copying the existing code for Register Listener and Register Game Object.

From my personal testing this works as expected, but I'm not deeply familiar with the Wwise API or programming for production use, so I've probably missed some error checking somewhere and haven't run any of the presumably standard tests/analysis. Additionally, I couldn't figure out how to easily get the current Listener Game Object, so I wasn't able to make custom nodes that would act as distance probes themselves.

Please consider this pull request, or otherwise just copying and fixing my code for inclusion in the next release! :)