### PR TITLE
Expose Waapi Port in the Integration Settings

### DIFF
--- a/addons/Wwise/native/src/editor/waapi_picker/waapi_picker.cpp
+++ b/addons/Wwise/native/src/editor/waapi_picker/waapi_picker.cpp
@@ -623,7 +623,8 @@ void WaapiPicker::_enter_tree()
 			"text_changed", callable_mp(this, &WaapiPicker::_on_search_text_changed));
 	AKASSERT(error == Error::OK);
 
-	Waapi::get_singleton()->connect_client("127.0.0.1", 8080);
+	auto port = ProjectSettings::get_singleton()->get_setting("wwise/communication_settings/waapi_port", 8080);
+	Waapi::get_singleton()->connect_client("127.0.0.1", port);
 
 	_on_refresh_project_button_up();
 }
@@ -699,7 +700,8 @@ void WaapiPicker::_on_refresh_project_button_up()
 	bool connect_result{};
 	if (!Waapi::get_singleton()->is_client_connected())
 	{
-		connect_result = Waapi::get_singleton()->connect_client("127.0.0.1", 8080);
+		auto port = ProjectSettings::get_singleton()->get_setting("wwise/communication_settings/waapi_port", 8080);
+		connect_result = Waapi::get_singleton()->connect_client("127.0.0.1", port);
 		emit_signal("connection_changed", connect_result);
 	}
 	else
@@ -741,7 +743,8 @@ void WaapiPicker::_on_export_soundbanks_button_up()
 	bool connect_result{};
 	if (!Waapi::get_singleton()->is_client_connected())
 	{
-		connect_result = Waapi::get_singleton()->connect_client("127.0.0.1", 8080);
+		auto port = ProjectSettings::get_singleton()->get_setting("wwise/communication_settings/waapi_port", 8080);
+		connect_result = Waapi::get_singleton()->connect_client("127.0.0.1", port);
 		emit_signal("connection_changed", connect_result);
 	}
 	else
@@ -798,7 +801,8 @@ void WaapiPicker::_on_file_dialog_file_selected(const String& path)
 	bool connect_result{};
 	if (!Waapi::get_singleton()->is_client_connected())
 	{
-		connect_result = Waapi::get_singleton()->connect_client("127.0.0.1", 8080);
+		auto port = ProjectSettings::get_singleton()->get_setting("wwise/communication_settings/waapi_port", 8080);
+		connect_result = Waapi::get_singleton()->connect_client("127.0.0.1", port);
 	}
 	else
 	{

--- a/addons/Wwise/native/src/wwise_settings.cpp
+++ b/addons/Wwise/native/src/wwise_settings.cpp
@@ -94,6 +94,7 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "command_port", 0, Variant::Type::INT);
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "initialize_system_comms", true, Variant::Type::BOOL);
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "network_name", "", Variant::Type::STRING);
+	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "waapi_port", 8080, Variant::Type::INT);
 
 	// macOS advanced settings
 	add_setting(WWISE_MACOS_ADVANCED_SETTINGS_PATH + "audio_API", 3, Variant::Type::INT, PROPERTY_HINT_FLAGS,


### PR DESCRIPTION
### Hello!
I'm currently playing around with the Wwise Godot Integration and noticed that the port to establish a connection with the Waapi Picker must be 8080. I exposed it to be a setting that can be editied to match the Wamp Port in Wwise.