### PR TITLE
Refactor `set_game_object_output_bus_volume` to allow for `AK_INVALID_GAME_OBJECT` (null) parameter

### DIFF
--- a/addons/Wwise/native/doc/Wwise.xml
+++ b/addons/Wwise/native/doc/Wwise.xml
@@ -457,6 +457,8 @@
 			<description>
 				Sets the Output Bus Volume of the given [param game_object]. Calls
 				[code]AK::SoundEngine::SetGameObjectOutputBusVolume[/code].[br][br]
+				Set [param listener] to [code]null[/code] to set the Output Bus Volume for all
+				connected listeners.[br][br]
 				Returns [code]true[/code] if setting the Output Bus Volume succeeded.
 			</description>
 		</method>

--- a/addons/Wwise/native/src/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/wwise_gdextension.cpp
@@ -833,9 +833,15 @@ Dictionary Wwise::get_playing_segment_info(const unsigned int playing_id, const 
 
 bool Wwise::set_game_object_output_bus_volume(const Object* game_object, const Object* listener, float f_control_value)
 {
-	return ERROR_CHECK(
-			AK::SoundEngine::SetGameObjectOutputBusVolume(static_cast<AkGameObjectID>(game_object->get_instance_id()),
-					static_cast<AkGameObjectID>(listener->get_instance_id()), f_control_value));
+	AkGameObjectID listener_obj_id{ AK_INVALID_GAME_OBJECT };
+
+	if (listener)
+	{
+		listener_obj_id = static_cast<AkGameObjectID>(listener->get_instance_id());
+	}
+
+	return ERROR_CHECK(AK::SoundEngine::SetGameObjectOutputBusVolume(
+			static_cast<AkGameObjectID>(game_object->get_instance_id()), listener_obj_id, f_control_value));
 }
 
 bool Wwise::set_game_object_aux_send_values(


### PR DESCRIPTION
This PR refactors the `set_game_object_output_bus_volume` function in `wwise_gdextension.cpp`, enabling the use of `AK_INVALID_GAME_OBJECT` (null in GDScript) as a parameter. Fixes #96.