### PR TITLE
Fix failing tests (Bank loading, cookie wrapper crash, get rtpc value)

### DIFF
--- a/addons/Wwise/tests/ak_test_framework.gd
+++ b/addons/Wwise/tests/ak_test_framework.gd
@@ -6,8 +6,8 @@ var banks_loaded = false
 
 
 func load_test_banks():
-	Wwise.load_bank_id(AK.BANKS.INIT)
-	Wwise.load_bank_id(AK.BANKS.TESTBANK)
+	Wwise.load_bank("Init")
+	Wwise.load_bank("TestBank")
 	banks_loaded = true
 
 

--- a/addons/Wwise/tests/test_wwise.gd
+++ b/addons/Wwise/tests/test_wwise.gd
@@ -2,6 +2,7 @@ extends "res://addons/Wwise/tests/ak_test.gd"
 
 const AK = preload("res://addons/Wwise/tests/GeneratedSoundBanks/wwise_ids_tests.gd")
 var mesh_instance: MeshInstance3D
+var cookie_wrapper = CookieWrapper.new()
 
 
 func before_all():
@@ -143,11 +144,9 @@ func test_post_event() -> bool:
 
 func test_post_event_callback() -> bool:
 	var node = register_3d_game_obj()
-	var cookie_wrapper = CookieWrapper.new()
 	cookie_wrapper.cookie = func(data): pass
 	var result = Wwise.post_event_callback("MUSIC", AkUtils.AK_DURATION, node, cookie_wrapper)
 	unregister_3d_game_obj(node)
-	cookie_wrapper.call_deferred("free")
 	return ak_assert(result)
 
 
@@ -160,13 +159,11 @@ func test_post_event_id() -> bool:
 
 func test_post_event_id_callback() -> bool:
 	var node = register_3d_game_obj()
-	var cookie_wrapper = CookieWrapper.new()
 	cookie_wrapper.cookie = func(data): pass
 	var result = Wwise.post_event_id_callback(
 		AK.EVENTS.MUSIC, AkUtils.AK_DURATION, node, cookie_wrapper
 	)
 	unregister_3d_game_obj(node)
-	cookie_wrapper.call_deferred("free")
 	return ak_assert(result)
 
 
@@ -199,7 +196,7 @@ func test_set_state_id() -> bool:
 func test_get_rtpc_value() -> bool:
 	var node = register_3d_game_obj()
 	Wwise.set_rtpc_value("Enemies", 3.0, node)
-	await get_tree().process_frame
+	await get_tree().create_timer(1).timeout
 	var value = Wwise.get_rtpc_value("Enemies", node)
 	unregister_3d_game_obj(node)
 	return ak_assert(value == 3.0)


### PR DESCRIPTION
This PR updates the test framework in the project to work correctly:

- Bank loading methods need to use the string version of the functions due to the "Use Soundbank names" option in the Wwise-Godot settings being enabled by default.

- The CookieWrapper object actually needs to persist during the tests. It cannot be a local variable.

- `test_get_rtpc_value` was failing (1 frame waiting was not enough).