### PR TITLE
Fixed ak_geometry transform setting in set_geometry

### DIFF
--- a/addons/Wwise/native/src/scene/ak_geometry.cpp
+++ b/addons/Wwise/native/src/scene/ak_geometry.cpp
@@ -106,7 +106,7 @@ bool AkGeometry::set_geometry(const MeshInstance3D* mesh_instance)
 
 	for (int i = 0; i < mdt->get_vertex_count(); ++i)
 	{
-		Vector3 vertex = to_global(mdt->get_vertex(i));
+		Vector3 vertex = mdt->get_vertex(i);
 		vertices.append(vertex);
 	}
 
@@ -133,7 +133,7 @@ bool AkGeometry::set_geometry(const MeshInstance3D* mesh_instance)
 	{
 		geometry_result = soundengine->set_geometry(vertices, triangles, acoustic_texture, transmission_loss_value,
 				this, enable_diffraction, enable_diffraction_on_boundary_edges);
-		instance_result = soundengine->set_geometry_instance(this, get_transform(), geometry_instance, room_node);
+		instance_result = soundengine->set_geometry_instance(this, get_global_transform(), geometry_instance, room_node);
 	}
 
 	vertices.clear();


### PR DESCRIPTION
The current code 
- effectively [places all geometry_instances on global (0, 0, 0)](https://github.com/alessandrofama/wwise-godot-integration/blob/main/addons/Wwise/native/src/scene/ak_geometry.cpp#L136)
    - (0, 0, 0) because AkGeometry needs to be child of MeshInstance3D, with AkGeometry most likely having position (0, 0, 0) and MeshInstance3D and its parents having whatever random positions
- places the vertices/triangles of the AkGeometry [according the global transform of the vertices themselves](https://github.com/alessandrofama/wwise-godot-integration/blob/main/addons/Wwise/native/src/scene/ak_geometry.cpp#L109)

When inspected in Wwise Game Object 3D Viewer the diffraction edges/shapes look ok, as the diffraction shapes are placed at the correct world position, just with the geometry_instance being at (0, 0, 0).

---

The problem is that when the game is tested, the diffraction and obstruction is not audible, especially when the AkGeometries are further away from global (0, 0, 0). The same can be seen in Wwise Game Object 3D Viewer while standing behind an AkGeometry. If I understand correctly https://github.com/alessandrofama/wwise-godot-integration/blob/main/addons/Wwise/native/src/scene/ak_geometry.cpp#L136 places the obstruction shape at the global (0, 0, 0) which then in its turn brakes also the computation of diffraction, even though the diffraction shape is in the "correct" world position.

---

This PR makes
- The transform of geometry_instance to its global transform
- The transform of vertices/triangles to be relative to AkGeometry's local (0, 0, 0)

This effectively makes both diffraction and obstruction shapes and path position themselves correctly, which can be inspected both in Wwise Game Object 3D Viewer and in game.

Testcase project https://github.com/artemkloko/wwise-godot-audio-test

---

🙇 Big thanks to the author and the contributors, this is 🔥