### PR TITLE
Fix enter/exit room bug

### DIFF
--- a/addons/Wwise/native/src/scene/ak_event.cpp
+++ b/addons/Wwise/native/src/scene/ak_event.cpp
@@ -194,7 +194,7 @@ void AkEvent3D::_bind_methods()
 			D_METHOD("set_is_environment_aware", "is_environment_aware"), &AkEvent3D::set_is_environment_aware);
 	ClassDB::bind_method(D_METHOD("get_is_environment_aware"), &AkEvent3D::get_is_environment_aware);
 	ClassDB::bind_method(D_METHOD("set_room_id", "room_id"), &AkEvent3D::set_room_id);
-    ClassDB::bind_method(D_METHOD("get_room_id"), &AkEvent3D::get_room_id);
+	ClassDB::bind_method(D_METHOD("get_room_id"), &AkEvent3D::get_room_id);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "event", PROPERTY_HINT_NONE), "set_event", "get_event");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "trigger_on", PROPERTY_HINT_ENUM, "None,Enter Tree,Ready,Exit Tree"),

--- a/addons/Wwise/native/src/scene/ak_event.cpp
+++ b/addons/Wwise/native/src/scene/ak_event.cpp
@@ -193,6 +193,8 @@ void AkEvent3D::_bind_methods()
 	ClassDB::bind_method(
 			D_METHOD("set_is_environment_aware", "is_environment_aware"), &AkEvent3D::set_is_environment_aware);
 	ClassDB::bind_method(D_METHOD("get_is_environment_aware"), &AkEvent3D::get_is_environment_aware);
+	ClassDB::bind_method(D_METHOD("set_room_id", "room_id"), &AkEvent3D::set_room_id);
+    ClassDB::bind_method(D_METHOD("get_room_id"), &AkEvent3D::get_room_id);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "event", PROPERTY_HINT_NONE), "set_event", "get_event");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "trigger_on", PROPERTY_HINT_ENUM, "None,Enter Tree,Ready,Exit Tree"),
@@ -206,6 +208,7 @@ void AkEvent3D::_bind_methods()
 			"set_interpolation_mode", "get_interpolation_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_environment_aware", PROPERTY_HINT_NONE), "set_is_environment_aware",
 			"get_is_environment_aware");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "room_id", PROPERTY_HINT_NONE), "set_room_id", "get_room_id");
 
 	ADD_ALL_AK_EVENT_SIGNALS;
 }
@@ -379,3 +382,7 @@ void AkEvent3D::set_is_environment_aware(bool is_environment_aware)
 }
 
 bool AkEvent3D::get_is_environment_aware() const { return is_environment_aware; }
+
+void AkEvent3D::set_room_id(int room_id) {this->room_id = room_id;}
+
+int AkEvent3D::get_room_id() const {return room_id;}

--- a/addons/Wwise/native/src/scene/ak_event.h
+++ b/addons/Wwise/native/src/scene/ak_event.h
@@ -122,7 +122,7 @@ public:
 	bool get_is_environment_aware() const;
 
 	void set_room_id(int room_id);
-    int get_room_id() const;
+	int get_room_id() const;
 };
 
 } //namespace godot

--- a/addons/Wwise/native/src/scene/ak_event.h
+++ b/addons/Wwise/native/src/scene/ak_event.h
@@ -85,6 +85,8 @@ private:
 
 	void check_signal_connections();
 
+	int room_id = INVALID_ROOM_ID;
+
 public:
 	AkEnvironmentData* environment_data = nullptr;
 
@@ -118,6 +120,9 @@ public:
 
 	void set_is_environment_aware(bool is_environment_aware);
 	bool get_is_environment_aware() const;
+
+	void set_room_id(int room_id);
+    int get_room_id() const;
 };
 
 } //namespace godot

--- a/addons/Wwise/native/src/scene/ak_listener.cpp
+++ b/addons/Wwise/native/src/scene/ak_listener.cpp
@@ -32,8 +32,11 @@ void AkListener3D::_bind_methods()
 {
 	ClassDB::bind_method(D_METHOD("set_is_spatial", "is_spatial"), &AkListener3D::set_is_spatial);
 	ClassDB::bind_method(D_METHOD("get_is_spatial"), &AkListener3D::get_is_spatial);
+	ClassDB::bind_method(D_METHOD("set_room_id", "room_id"), &AkListener3D::set_room_id);
+    ClassDB::bind_method(D_METHOD("get_room_id"), &AkListener3D::get_room_id);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_spatial", PROPERTY_HINT_NONE), "set_is_spatial", "get_is_spatial");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "room_id", PROPERTY_HINT_NONE), "set_room_id", "get_room_id");
 }
 
 void AkListener3D::_enter_tree()
@@ -68,3 +71,7 @@ void AkListener3D::_process(double p_delta)
 void AkListener3D::set_is_spatial(bool is_spatial) { this->is_spatial = is_spatial; }
 
 bool AkListener3D::get_is_spatial() const { return is_spatial; }
+
+void AkListener3D::set_room_id(int room_id) {this->room_id = room_id;}
+
+int AkListener3D::get_room_id() const {return room_id;}

--- a/addons/Wwise/native/src/scene/ak_listener.cpp
+++ b/addons/Wwise/native/src/scene/ak_listener.cpp
@@ -33,7 +33,7 @@ void AkListener3D::_bind_methods()
 	ClassDB::bind_method(D_METHOD("set_is_spatial", "is_spatial"), &AkListener3D::set_is_spatial);
 	ClassDB::bind_method(D_METHOD("get_is_spatial"), &AkListener3D::get_is_spatial);
 	ClassDB::bind_method(D_METHOD("set_room_id", "room_id"), &AkListener3D::set_room_id);
-    ClassDB::bind_method(D_METHOD("get_room_id"), &AkListener3D::get_room_id);
+	ClassDB::bind_method(D_METHOD("get_room_id"), &AkListener3D::get_room_id);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_spatial", PROPERTY_HINT_NONE), "set_is_spatial", "get_is_spatial");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "room_id", PROPERTY_HINT_NONE), "set_room_id", "get_room_id");

--- a/addons/Wwise/native/src/scene/ak_listener.h
+++ b/addons/Wwise/native/src/scene/ak_listener.h
@@ -29,6 +29,7 @@ protected:
 
 private:
 	bool is_spatial{};
+	int room_id = INVALID_ROOM_ID;
 
 public:
 	virtual void _enter_tree() override;
@@ -36,6 +37,9 @@ public:
 
 	void set_is_spatial(bool is_spatial);
 	bool get_is_spatial() const;
+
+	void set_room_id(int room_id);
+    int get_room_id() const;
 };
 
 } // namespace godot

--- a/addons/Wwise/native/src/scene/ak_listener.h
+++ b/addons/Wwise/native/src/scene/ak_listener.h
@@ -39,7 +39,7 @@ public:
 	bool get_is_spatial() const;
 
 	void set_room_id(int room_id);
-    int get_room_id() const;
+	int get_room_id() const;
 };
 
 } // namespace godot

--- a/addons/Wwise/native/src/scene/ak_room.cpp
+++ b/addons/Wwise/native/src/scene/ak_room.cpp
@@ -80,18 +80,18 @@ void AkRoom::_on_area_entered(const Area3D* area)
 	{
 		if (parent->get_class() == "AkEvent3D" || parent->get_class() == "AkListener3D")
 		{
-            // If we have an AkListener3D or an AkEvent3D, keep track
-            // of the room it's entering.
-            AkListener3D* listener = static_cast<AkListener3D*>(parent);
-            AkEvent3D* event = static_cast<AkEvent3D*>(parent);
-            if (listener)
-            {
-                listener->set_room_id(static_cast<AkGameObjectID>(this->get_instance_id()));
-            }
-            else if (event)
-            {
-                event->set_room_id(static_cast<AkGameObjectID>(this->get_instance_id()));
-            }
+			// If we have an AkListener3D or an AkEvent3D, keep track
+			// of the room it's entering.
+			AkListener3D* listener = static_cast<AkListener3D*>(parent);
+			AkEvent3D* event = static_cast<AkEvent3D*>(parent);
+			if (listener)
+			{
+			    listener->set_room_id(static_cast<AkGameObjectID>(this->get_instance_id()));
+			}
+			else if (event)
+			{
+			    event->set_room_id(static_cast<AkGameObjectID>(this->get_instance_id()));
+			}
 
 			Wwise* soundengine = Wwise::get_singleton();
 
@@ -111,31 +111,31 @@ void AkRoom::_on_area_exited(const Area3D* area)
 	{
 		if (parent->get_class() == "AkEvent3D" || parent->get_class() == "AkListener3D")
 		{
-            // Check if the AkListener3D or AkEvent3D is leaving the
-            // room they are in to go outside.
-            //
-            // If they enter a different room, then the
-            // _on_area_entered() method for the different room will be
-            // called, setting the listener/event's room ID to that room.
-            //
-            // In contrast, if the event/listener goes outside, then
-            // there is no call to _on_area_entered() and the
-            // event/ listener's room ID is the same as the room they
-            // are leaving. In this case, we call
-            // remove_game_object_from_room() and set the room
-            // to INVALID_ROOM_ID.
-            bool isGoingOutside = false;
+			// Check if the AkListener3D or AkEvent3D is leaving the
+			// room they are in to go outside.
+			//
+			// If they enter a different room, then the
+			// _on_area_entered() method for the different room will be
+			// called, setting the listener/event's room ID to that room.
+			//
+			// In contrast, if the event/listener goes outside, then
+			// there is no call to _on_area_entered() and the
+			// event/ listener's room ID is the same as the room they
+			// are leaving. In this case, we call
+			// remove_game_object_from_room() and set the room
+			// to INVALID_ROOM_ID.
+			bool isGoingOutside = false;
 
-            AkListener3D* listener = static_cast<AkListener3D*>(parent);
-            AkEvent3D* event = static_cast<AkEvent3D*>(parent);
-            if (listener)
-            {
-                isGoingOutside = listener->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
-            }
-            else if (event)
-            {
-                isGoingOutside = event->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
-            }
+			AkListener3D* listener = static_cast<AkListener3D*>(parent);
+			AkEvent3D* event = static_cast<AkEvent3D*>(parent);
+			if (listener)
+			{
+				isGoingOutside = listener->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
+			}
+			else if (event)
+			{
+				isGoingOutside = event->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
+			}
 
 			Wwise* soundengine = Wwise::get_singleton();
 

--- a/addons/Wwise/native/src/scene/ak_room.cpp
+++ b/addons/Wwise/native/src/scene/ak_room.cpp
@@ -112,28 +112,34 @@ void AkRoom::_on_area_exited(const Area3D* area)
 		if (parent->get_class() == "AkEvent3D" || parent->get_class() == "AkListener3D")
 		{
             // Check if the AkListener3D or AkEvent3D is leaving the
-            // room they are in. If they are, it means they are leaving
-            // a room and going outside and we set their room ID
-            // to INVALID_ROOM_ID. If, however, they are exiting a
-            // different room than they are in, it means they are
-            // going to another room, and there is no need to make
-            // a call to remove_game_object_from_room().
-            bool leavingTheSameRoom = false;
+            // room they are in to go outside.
+            //
+            // If they enter a different room, then the
+            // _on_area_entered() method for the different room will be
+            // called, setting the listener/event's room ID to that room.
+            //
+            // In contrast, if the event/listener goes outside, then
+            // there is no call to _on_area_entered() and the
+            // event/ listener's room ID is the same as the room they
+            // are leaving. In this case, we call
+            // remove_game_object_from_room() and set the room
+            // to INVALID_ROOM_ID.
+            bool isGoingOutside = false;
 
             AkListener3D* listener = static_cast<AkListener3D*>(parent);
             AkEvent3D* event = static_cast<AkEvent3D*>(parent);
             if (listener)
             {
-                leavingTheSameRoom = listener->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
+                isGoingOutside = listener->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
             }
             else if (event)
             {
-                leavingTheSameRoom = event->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
+                isGoingOutside = event->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());
             }
 
 			Wwise* soundengine = Wwise::get_singleton();
 
-			if (soundengine && leavingTheSameRoom)
+			if (soundengine && isGoingOutside)
 			{
 				soundengine->remove_game_object_from_room(parent);
 			}

--- a/addons/Wwise/native/src/scene/ak_room.h
+++ b/addons/Wwise/native/src/scene/ak_room.h
@@ -2,6 +2,8 @@
 #define AK_ROOM_H
 
 #include "ak_geometry.h"
+#include "ak_listener.h"
+#include "ak_event.h"
 #include "wwise_gdextension.h"
 #include <godot_cpp/classes/area3d.hpp>
 #include <godot_cpp/classes/engine.hpp>


### PR DESCRIPTION
Hi Alessandro,

This is the fix for the enter/exit room bug. Prior to this fix, sound would drop out as we changed rooms because after the player entered the new room, it would call _on_area_exited() on the old room, which would set the player's room ID to INVALID_ROOM_ID.

To fix this problems we make two substantive code changes:
1. When the player enters a new room, have the method _on_area_entered() set the player's room ID to the room they are in. If a player goes outside, then _on_area_entered() is not called because outdoors is not a room.
2. When the player exits a room compare the room the player is in with that they're exiting. If they are the same (because the player has not entered another room) it means the player is going outside and we set the room ID to INVALID_ROOM_ID.

I've left a detailed comment in _on_area_exited() explaining this.

All tests pass locally; ideally we would have an automated test in a game environment simulating the transition between two rooms, but I'm not sure if that is something we have right now.

Thanks!