### PR TITLE
Fix AkRoom not detecting moving between rooms

### DIFF
--- a/addons/Wwise/native/src/scene/ak_event.cpp
+++ b/addons/Wwise/native/src/scene/ak_event.cpp
@@ -381,6 +381,6 @@ void AkEvent3D::set_is_environment_aware(bool is_environment_aware)
 
 bool AkEvent3D::get_is_environment_aware() const { return is_environment_aware; }
 
-void AkEvent3D::set_room_id(int room_id) { this->room_id = room_id; }
+void AkEvent3D::set_room_id(uint64_t room_id) { this->room_id = room_id; }
 
-int AkEvent3D::get_room_id() const { return room_id; }
+uint64_t AkEvent3D::get_room_id() const { return room_id; }

--- a/addons/Wwise/native/src/scene/ak_event.h
+++ b/addons/Wwise/native/src/scene/ak_event.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "AK/SoundEngine/Common/AkTypes.h"
-#include "core/wwise_cookie.h"
 #include "core/ak_utils.h"
 #include "core/utils.h"
+#include "core/wwise_cookie.h"
 #include "core/wwise_gdextension.h"
+#include "scene/ak_environment_data.h"
 #include <godot_cpp/classes/node2d.hpp>
 #include <godot_cpp/classes/node3d.hpp>
 #include <godot_cpp/classes/thread.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
-#include "scene/ak_environment_data.h"
 
 using namespace godot;
 
@@ -88,7 +88,7 @@ private:
 
 	void check_signal_connections();
 
-	int room_id = INVALID_ROOM_ID;
+	uint64_t room_id = INVALID_ROOM_ID;
 
 public:
 	AkEnvironmentData* environment_data = nullptr;
@@ -124,6 +124,6 @@ public:
 	void set_is_environment_aware(bool is_environment_aware);
 	bool get_is_environment_aware() const;
 
-	void set_room_id(int room_id);
-	int get_room_id() const;
+	void set_room_id(uint64_t room_id);
+	uint64_t get_room_id() const;
 };

--- a/addons/Wwise/native/src/scene/ak_listener.cpp
+++ b/addons/Wwise/native/src/scene/ak_listener.cpp
@@ -70,6 +70,6 @@ void AkListener3D::set_is_spatial(bool is_spatial) { this->is_spatial = is_spati
 
 bool AkListener3D::get_is_spatial() const { return is_spatial; }
 
-void AkListener3D::set_room_id(int room_id) { this->room_id = room_id; }
+void AkListener3D::set_room_id(uint64_t room_id) { this->room_id = room_id; }
 
-int AkListener3D::get_room_id() const { return room_id; }
+uint64_t AkListener3D::get_room_id() const { return room_id; }

--- a/addons/Wwise/native/src/scene/ak_listener.h
+++ b/addons/Wwise/native/src/scene/ak_listener.h
@@ -28,7 +28,7 @@ protected:
 
 private:
 	bool is_spatial{};
-	int room_id = INVALID_ROOM_ID;
+	uint64_t room_id = INVALID_ROOM_ID;
 
 public:
 	virtual void _enter_tree() override;
@@ -37,6 +37,6 @@ public:
 	void set_is_spatial(bool is_spatial);
 	bool get_is_spatial() const;
 
-	void set_room_id(int room_id);
-	int get_room_id() const;
+	void set_room_id(uint64_t room_id);
+	uint64_t get_room_id() const;
 };

--- a/addons/Wwise/native/src/scene/ak_room.cpp
+++ b/addons/Wwise/native/src/scene/ak_room.cpp
@@ -80,8 +80,8 @@ void AkRoom::_on_area_entered(const Area3D* area)
 		{
 			// If we have an AkListener3D or an AkEvent3D, keep track
 			// of the room it's entering.
-			AkListener3D* listener = static_cast<AkListener3D*>(parent);
-			AkEvent3D* event = static_cast<AkEvent3D*>(parent);
+			AkListener3D* listener = Object::cast_to<AkListener3D>(parent);
+			AkEvent3D* event = Object::cast_to<AkEvent3D>(parent);
 			if (listener)
 			{
 				listener->set_room_id(static_cast<AkGameObjectID>(this->get_instance_id()));
@@ -124,8 +124,8 @@ void AkRoom::_on_area_exited(const Area3D* area)
 			// to INVALID_ROOM_ID.
 			bool isGoingOutside = false;
 
-			AkListener3D* listener = static_cast<AkListener3D*>(parent);
-			AkEvent3D* event = static_cast<AkEvent3D*>(parent);
+			AkListener3D* listener = Object::cast_to<AkListener3D>(parent);
+			AkEvent3D* event = Object::cast_to<AkEvent3D>(parent);
 			if (listener)
 			{
 				isGoingOutside = listener->get_room_id() == static_cast<AkGameObjectID>(this->get_instance_id());


### PR DESCRIPTION
1) We need to use Object::cast_to instead of static_cast in GDExtension
2) Object::get_instance_id is a uint64_t, so the room id in the AkEvent3D and AkListener3D needs to be the same
