### PR TITLE
Add Acoustic Texture Support for AkGeometry

### DIFF
--- a/addons/Wwise/native/src/core/wwise_gdextension.h
+++ b/addons/Wwise/native/src/core/wwise_gdextension.h
@@ -138,7 +138,7 @@ public:
 	bool set_object_obstruction_and_occlusion(
 			const Object* game_object, const Object* listener, float f_calculated_obs, float f_calculated_occ);
 
-	bool set_geometry(const Array vertices, const Array triangles, const Ref<Resource>& acoustic_texture,
+	bool set_geometry(const Array vertices, const Array triangles, const Dictionary& acoustic_texture,
 			float transmission_loss_value, const Object* game_object, bool enable_diffraction,
 			bool enable_diffraction_on_boundary_edges);
 	bool remove_geometry(const Object* game_object);

--- a/addons/Wwise/native/src/editor/ak_inspector_plugin.cpp
+++ b/addons/Wwise/native/src/editor/ak_inspector_plugin.cpp
@@ -71,6 +71,11 @@ Dictionary AkInspectorTree::get_wwise_ids(const AkEditorUtils::AkType ak_type)
 						type_constant = "AUX_BUSSES";
 						break;
 					}
+					case AkEditorUtils::AkType::AKTYPE_ACOUSTIC_TEXTURE:
+					{
+						type_constant = "ACOUSTIC_TEXTURES";
+						break;
+					}
 					default:
 						break;
 				}
@@ -419,7 +424,7 @@ bool AkInspectorEditorInspectorPlugin::_can_handle(Object* object) const
 	return (object->get_class() == "AkBank" || object->get_class() == "AkState" || object->get_class() == "AkSwitch" ||
 			object->get_class() == "AkEvent2D" || object->get_class() == "AkEvent3D" ||
 			object->get_class() == "AkEnvironment" || object->get_class() == "AkRoom" ||
-			object->get_class() == "AkEarlyReflections");
+			object->get_class() == "AkEarlyReflections" || object->get_class() == "AkGeometry");
 }
 
 bool AkInspectorEditorInspectorPlugin::_parse_property(Object* object, Variant::Type type, const String& name,
@@ -480,6 +485,13 @@ bool AkInspectorEditorInspectorPlugin::_parse_property(Object* object, Variant::
 		{
 			AkInspectorEditorProperty* property = memnew(AkInspectorEditorProperty);
 			property->init(AkEditorUtils::AkType::AKTYPE_RTPC);
+			add_property_editor(name, property);
+			return true;
+		}
+		else if (name == "acoustic_texture")
+		{
+			AkInspectorEditorProperty* property = memnew(AkInspectorEditorProperty);
+			property->init(AkEditorUtils::AkType::AKTYPE_ACOUSTIC_TEXTURE);
 			add_property_editor(name, property);
 			return true;
 		}

--- a/addons/Wwise/native/src/editor/ak_inspector_plugin.h
+++ b/addons/Wwise/native/src/editor/ak_inspector_plugin.h
@@ -92,6 +92,8 @@ private:
 				return AkInspectorEditorPropertyInfo{ "Select Bus...", "Search Busses..." };
 			case AkEditorUtils::AkType::AKTYPE_AUX_BUS:
 				return AkInspectorEditorPropertyInfo{ "Select Aux Bus...", "Search Aux Busses..." };
+			case AkEditorUtils::AkType::AKTYPE_ACOUSTIC_TEXTURE:
+				return AkInspectorEditorPropertyInfo{ "Select Acoustic Texture...", "Search Acoustic Textures..." };
 			default:
 				return AkInspectorEditorPropertyInfo{ "Default Select Label", "Default Search Label" };
 		}

--- a/addons/Wwise/native/src/editor/ak_waapi_picker.cpp
+++ b/addons/Wwise/native/src/editor/ak_waapi_picker.cpp
@@ -385,6 +385,7 @@ void AkWaapiPicker::generate_ids(const Array& data)
 	Array aux_bus_array;
 	Array audio_device_array;
 	Array external_src_array;
+	Array acoustic_texture_array;
 
 	for (int i = 0; i < data.size(); ++i)
 	{
@@ -437,6 +438,10 @@ void AkWaapiPicker::generate_ids(const Array& data)
 		{
 			external_src_array.append(data[i]);
 		}
+		else if (type == "AcousticTexture")
+		{
+			acoustic_texture_array.append(data[i]);
+		}
 	}
 
 	Dictionary init_soundbank;
@@ -458,6 +463,7 @@ void AkWaapiPicker::generate_ids(const Array& data)
 	create_class(aux_bus_array, "AUX_BUSSES");
 	create_class(audio_device_array, "AUDIO_DEVICES");
 	create_class(external_src_array, "EXTERNAL_SOURCES");
+	create_class(acoustic_texture_array, "ACOUSTIC_TEXTURES");
 }
 
 void AkWaapiPicker::create_class(const Array& data, const String& type)
@@ -812,7 +818,7 @@ void AkWaapiPicker::_on_file_dialog_file_selected(const String& path)
 		Dictionary args;
 		Dictionary of_type;
 		Array type_array = Array::make("Event", "StateGroup", "State", "SwitchGroup", "Switch", "GameParameter",
-				"Trigger", "SoundBank", "Bus", "AuxBus", "AudioDevice", "ExternalSource");
+				"Trigger", "SoundBank", "Bus", "AuxBus", "AudioDevice", "ExternalSource", "AcousticTexture");
 
 		of_type["ofType"] = type_array;
 		args["from"] = of_type;

--- a/addons/Wwise/native/src/scene/ak_geometry.cpp
+++ b/addons/Wwise/native/src/scene/ak_geometry.cpp
@@ -26,9 +26,10 @@ void AkGeometry::_bind_methods()
 			"get_enable_diffraction");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enable_diffraction_on_boundary_edges", PROPERTY_HINT_NONE),
 			"set_enable_diffraction_on_boundary_edges", "get_enable_diffraction_on_boundary_edges");
-	// todo(alex): Add proper hint for acoustic texture
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "acoustic_texture", PROPERTY_HINT_NONE), "set_acoustic_texture",
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "acoustic_texture", PROPERTY_HINT_NONE), "set_acoustic_texture",
 			"get_acoustic_texture");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "transmission_loss_value", PROPERTY_HINT_NONE),
+			"set_transmission_loss_value", "get_transmission_loss_value");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "associated_room", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "AkRoom"),
 			"set_associated_room", "get_associated_room");
 }
@@ -60,6 +61,12 @@ void AkGeometry::add_indices(int a, int b, int c, int d)
 	indices.append(a);
 	indices.append(b);
 	indices.append(c);
+}
+
+AkGeometry::AkGeometry()
+{
+	acoustic_texture["name"] = "";
+	acoustic_texture["id"] = 0;
 }
 
 void AkGeometry::_enter_tree()
@@ -169,12 +176,9 @@ void AkGeometry::set_enable_diffraction_on_boundary_edges(bool enable_diffractio
 
 bool AkGeometry::get_enable_diffraction_on_boundary_edges() const { return enable_diffraction_on_boundary_edges; }
 
-void AkGeometry::set_acoustic_texture(const Ref<Resource>& acoustic_texture)
-{
-	this->acoustic_texture = acoustic_texture;
-}
+void AkGeometry::set_acoustic_texture(const Dictionary& acoustic_texture) { this->acoustic_texture = acoustic_texture; }
 
-Ref<Resource> AkGeometry::get_acoustic_texture() const { return acoustic_texture; }
+Dictionary AkGeometry::get_acoustic_texture() const { return acoustic_texture; }
 
 void AkGeometry::set_transmission_loss_value(float transmission_loss_value)
 {

--- a/addons/Wwise/native/src/scene/ak_geometry.h
+++ b/addons/Wwise/native/src/scene/ak_geometry.h
@@ -26,7 +26,7 @@ private:
 	bool is_static{ true };
 	bool enable_diffraction{};
 	bool enable_diffraction_on_boundary_edges{};
-	Ref<Resource> acoustic_texture{};
+	Dictionary acoustic_texture{};
 	float transmission_loss_value{ 1.0f };
 	NodePath associated_room{};
 
@@ -41,6 +41,7 @@ private:
 	void add_indices(int a, int b, int c, int d);
 
 public:
+	AkGeometry();
 	virtual void _enter_tree() override;
 	virtual void _exit_tree() override;
 	bool set_geometry(const MeshInstance3D* mesh_instance);
@@ -55,8 +56,8 @@ public:
 	void set_enable_diffraction_on_boundary_edges(bool enable_diffraction_on_boundary_edges);
 	bool get_enable_diffraction_on_boundary_edges() const;
 
-	void set_acoustic_texture(const Ref<Resource>& acoustic_texture);
-	Ref<Resource> get_acoustic_texture() const;
+	void set_acoustic_texture(const Dictionary& acoustic_texture);
+	Dictionary get_acoustic_texture() const;
 
 	void set_transmission_loss_value(float transmission_loss_value);
 	float get_transmission_loss_value() const;

--- a/addons/Wwise/tools/wwise_ids.template
+++ b/addons/Wwise/tools/wwise_ids.template
@@ -35,3 +35,7 @@ class AUX_BUSSES:
 class AUDIO_DEVICES:
 	const _dict = {
 	}
+
+class ACOUSTIC_TEXTURES:
+	const _dict = {
+	}


### PR DESCRIPTION
- Integrated Acoustic Texture support into the AkGeometry node, allowing to select an Acoustic Texture for the entire mesh surface via a new acoustic_texture property.
- Updated the ID generator to include Acoustic Textures in the Wwise ID generation workflow.
- Exposed the transmission loss value as a new property in AkGeometry.
- Updated relevant editor plugins, including the WAAPI picker and inspector, to handle Acoustic Textures and provide appropriate labels and search options.

Using Acoustic Textures will require regenerating the Wwise IDs in the WAAPI Picker.
