### PR TITLE
Fix AkGeometry reflections and right-handed to left-handed Transform conversion

### DIFF
--- a/addons/Wwise/native/src/core/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/core/wwise_gdextension.cpp
@@ -1003,10 +1003,11 @@ bool Wwise::set_geometry_instance(const Object* associated_geometry, const Trans
 
 	AkWorldTransform position_and_orientation{};
 	position_and_orientation.SetPosition(AK::ConvertAkVectorToAkVector64(position));
-	position_and_orientation.SetOrientation(orientation_front * -1.0f, orientation_top);
+	position_and_orientation.SetOrientation(orientation_front, orientation_top);
 	params.PositionAndOrientation = position_and_orientation;
-
-	vector3_to_akvector(transform.get_basis().get_scale(), params.Scale);
+	
+	Vector3 scale = transform.get_basis().get_scale();
+	params.Scale = { scale.x, scale.y, scale.z };
 
 	params.RoomID = associated_room ? static_cast<AkRoomID>(associated_room->get_instance_id())
 									: static_cast<AkRoomID>(INVALID_ROOM_ID);

--- a/addons/Wwise/native/src/scene/ak_geometry.cpp
+++ b/addons/Wwise/native/src/scene/ak_geometry.cpp
@@ -53,16 +53,6 @@ void AkGeometry::_notification(int p_what, bool reversed)
 	}
 }
 
-void AkGeometry::add_indices(int a, int b, int c, int d)
-{
-	indices.append(a);
-	indices.append(c);
-	indices.append(d);
-	indices.append(a);
-	indices.append(b);
-	indices.append(c);
-}
-
 AkGeometry::AkGeometry()
 {
 	acoustic_texture["name"] = "";
@@ -112,7 +102,7 @@ bool AkGeometry::set_geometry(const MeshInstance3D* mesh_instance)
 	for (int i = 0; i < mdt->get_vertex_count(); ++i)
 	{
 		Vector3 vertex = mdt->get_vertex(i);
-		vertices.append(vertex);
+		vertices.append(Vector3(vertex.x, vertex.y, -vertex.z));
 	}
 
 	for (int i = 0; i < mdt->get_face_count(); ++i)
@@ -121,8 +111,8 @@ bool AkGeometry::set_geometry(const MeshInstance3D* mesh_instance)
 		int point_1 = mdt->get_face_vertex(i, 1);
 		int point_2 = mdt->get_face_vertex(i, 2);
 		triangles.append(point_0);
-		triangles.append(point_1);
 		triangles.append(point_2);
+		triangles.append(point_1);
 	}
 
 	if (!associated_room.is_empty())

--- a/addons/Wwise/native/src/scene/ak_geometry.h
+++ b/addons/Wwise/native/src/scene/ak_geometry.h
@@ -38,7 +38,6 @@ private:
 	Array triangles{};
 	MeshInstance3D* mesh_instance{};
 	Object* geometry_instance{};
-	void add_indices(int a, int b, int c, int d);
 
 public:
 	AkGeometry();


### PR DESCRIPTION
This commit addresses issues with geometry reflections, primarily caused by discrepancies between right-handed (Godot) and left-handed (Wwise) coordinate systems.

- Corrected the orientation setup in Wwise::set_geometry_instance to align with the left-handed coordinate system used by Wwise.
- Fixed scaling conversion to ensure proper geometry transformations.
- Adjusted the Z-axis inversion for vertices in AkGeometry::set_geometry, ensuring compatibility with Wwise's coordinate system.
- Corrected triangle indexing to maintain the correct winding order.
- Removed the unused add_indices function from ak_geometry.h and its implementation in ak_geometry.cpp.