### PR TITLE
Update Wwise Integration to 24.1

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,8 +13,8 @@ on:
       - wwise_v2024.1
 env:
   BASE_BRANCH: ci
-  WWISE_VERSION: "2023.1.0"
-  GODOT_ENGINE_VERSION: "4.1.3"
+  WWISE_VERSION: "2024.1.0"
+  GODOT_ENGINE_VERSION: "4.3.0"
   GODOT_ENGINE_STAGE: "stable"
   INTEGRATION_VERSION: "3.0.0"
 
@@ -27,14 +27,14 @@ jobs:
       matrix:
         include:
           - name: Windows
-            os: "windows-2019"
+            os: "windows-2022"
             sdk-platform: windows
             scons-platform: windows
             release-flags: use_static_cpp=true
             artifact-name: windows
 
           - name: macOS
-            os: "macos-13"
+            os: "macos-14"
             sdk-platform: mac
             scons-platform: macos
             artifact-name: macos
@@ -46,7 +46,7 @@ jobs:
             artifact-name: linux
 
           - name: iOS
-            os: "macos-13"
+            os: "macos-14"
             sdk-platform: ios
             scons-platform: ios
             debug-flags: arch=arm64 ios_min_version=11.0
@@ -126,82 +126,82 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.4.0
         if: steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         with:
-          url: "https://www.dropbox.com/scl/fi/xlrcmxbmxsmy58tp33uiw/wwise_sdk_2023.1.0_base.zip?rlkey=30ut2n1g1bi5dp33y923epsbd&dl=1"
+          url: "https://www.dropbox.com/scl/fi/ur2kuz1u9fyckhnl6ddy0/wwise_sdk_2024.1.0_base.zip?rlkey=qua0igr1cz2jhis4bhynut3pm&st=sfbaic74&dl=1"
           target: ./addons/Wwise/native/wwise_sdk/
 
       - name: Download Wwise SDK (Windows)
         uses: suisei-cn/actions-download-file@v1.4.0
         if: runner.os == 'Windows' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         with:
-          url: "https://www.dropbox.com/scl/fi/kt51rpzdbvgzt6wsnclhe/wwise_sdk_2023.1.0_win.zip?rlkey=ossw4of3bxjat6fbempev6jbr&dl=1"
+          url: "https://www.dropbox.com/scl/fi/3pwzimrqktxgbjvi8k2in/wwise_sdk_2024.1.0_win.zip?rlkey=6qveo4q34pkcxg9ck6bzrvdag&st=g443kewe&dl=1"
           target: ./addons/Wwise/native/wwise_sdk/
 
       - name: Download Wwise SDK (macOS)
         uses: suisei-cn/actions-download-file@v1.4.0
         if: runner.os == 'MacOS' && matrix.sdk-platform == 'mac' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         with:
-          url: "https://www.dropbox.com/scl/fi/97zus2pl7btnua0s5dhw1/wwise_sdk_2023.1.0_mac.zip?rlkey=v4io943jvor5ovbw7x6n5p6gm&dl=1"
+          url: "https://www.dropbox.com/scl/fi/qrz7hnofnlyswpe5ebg3w/wwise_sdk_2024.1.0_mac.zip?rlkey=1o2ee7h57d3rfuwgfzgeczcyv&st=lq5ofj2m&dl=1"
           target: ./addons/Wwise/native/wwise_sdk/
 
       - name: Download Wwise SDK (Linux)
         uses: suisei-cn/actions-download-file@v1.4.0
         if: runner.os == 'Linux' && matrix.sdk-platform == 'linux' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         with:
-          url: "https://www.dropbox.com/scl/fi/76dgnud1pg6bbctiruiy4/wwise_sdk_2023.1.0_linux.zip?rlkey=8oimalx8sj8klaze2hl35pbha&dl=1"
+          url: "https://www.dropbox.com/scl/fi/eo92g2m8qppeupdigtztw/wwise_sdk_2024.1.0_linux.zip?rlkey=exj40mnjhn1ggcz6p2o5bh7vd&st=kac8so10&dl=1"
           target: ./addons/Wwise/native/wwise_sdk/
 
       - name: Download Wwise SDK (iOS)
         uses: suisei-cn/actions-download-file@v1.4.0
         if: runner.os == 'MacOS' && matrix.sdk-platform == 'ios' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         with:
-          url: "https://www.dropbox.com/scl/fi/p0jknjqz3ahw4myzq5y1g/wwise_sdk_2023.1.0_ios.zip?rlkey=ybyvp3bavmh6h2r6csftsmtep&dl=1"
+          url: "https://www.dropbox.com/scl/fi/r5ztalylhm0ah3hfl97x1/wwise_sdk_2024.1.0_ios.zip?rlkey=sgr2cgfrueizdsq18bo5ypg8i&st=w0fmm6qy&dl=1"
           target: ./addons/Wwise/native/wwise_sdk/
 
       - name: Download Wwise SDK (Android)
         uses: suisei-cn/actions-download-file@v1.4.0
         if: runner.os == 'Linux' && matrix.sdk-platform == 'android' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         with:
-          url: "https://www.dropbox.com/scl/fi/0armk45ync2ijvrq5epgq/wwise_sdk_2023.1.0_android.zip?rlkey=twmaw7gc39bytxgenuc8baqml&dl=1"
+          url: "https://www.dropbox.com/scl/fi/72qu8b87c9nqiir92bsyc/wwise_sdk_2024.1.0_android.zip?rlkey=sjhgz76am8cyxwzbga24ngsyh&st=v2garhm3&dl=1"
           target: ./addons/Wwise/native/wwise_sdk/
 
       - name: Unzip SDK (Windows)
         if: runner.os == 'Windows' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         run: |
           cd ./addons/Wwise/native/wwise_sdk
-          7z x wwise_sdk_2023.1.0_base.zip
-          7z x wwise_sdk_2023.1.0_win.zip
+          7z x wwise_sdk_2024.1.0_base.zip
+          7z x wwise_sdk_2024.1.0_win.zip
           cd ../../../../
 
       - name: Unzip SDK (macOS)
         if: runner.os == 'MacOS' && matrix.sdk-platform == 'mac' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         run: |
           cd ./addons/Wwise/native/wwise_sdk
-          7z x wwise_sdk_2023.1.0_base.zip
-          7z x wwise_sdk_2023.1.0_mac.zip
+          7z x wwise_sdk_2024.1.0_base.zip
+          7z x wwise_sdk_2024.1.0_mac.zip
           cd ../../../../
 
       - name: Unzip SDK (Linux)
         if: runner.os == 'Linux' && matrix.sdk-platform == 'linux' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         run: |
           cd ./addons/Wwise/native/wwise_sdk
-          7z x wwise_sdk_2023.1.0_base.zip
-          7z x wwise_sdk_2023.1.0_linux.zip
+          7z x wwise_sdk_2024.1.0_base.zip
+          7z x wwise_sdk_2024.1.0_linux.zip
           cd ../../../../
 
       - name: Unzip SDK (iOS)
         if: runner.os == 'MacOS' && matrix.sdk-platform == 'ios' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         run: |
             cd ./addons/Wwise/native/wwise_sdk
-            7z x wwise_sdk_2023.1.0_base.zip
-            7z x wwise_sdk_2023.1.0_ios.zip
+            7z x wwise_sdk_2024.1.0_base.zip
+            7z x wwise_sdk_2024.1.0_ios.zip
             cd ../../../../
 
       - name: Unzip SDK (Android)
         if: runner.os == 'Linux' && matrix.sdk-platform == 'android' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         run: |
               cd ./addons/Wwise/native/wwise_sdk
-              7z x wwise_sdk_2023.1.0_base.zip
-              7z x wwise_sdk_2023.1.0_android.zip
+              7z x wwise_sdk_2024.1.0_base.zip
+              7z x wwise_sdk_2024.1.0_android.zip
               cd ../../../../
 
       - name: Compile Editor library

--- a/addons/Wwise/native/SConstruct
+++ b/addons/Wwise/native/SConstruct
@@ -106,16 +106,16 @@ wwise_soundengine_sample_path = ""
 if env["platform"] == "windows":
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/Win32/"
     if env["target"] in ("editor", "template_debug"):
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc160/Debug(StaticCRT)/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc170/Debug(StaticCRT)/lib/"
     else:
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc160/Release(StaticCRT)/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/x64_vc170/Release(StaticCRT)/lib/"
 
 if env["platform"] == "macos":
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/POSIX/"
     if env["target"] in ("editor", "template_debug"):
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/Mac/Debug/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/Mac_Xcode1500/Debug/lib/"
     else:
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/Mac/Release/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/Mac_Xcode1500/Release/lib/"
 
 if env["platform"] == "linux":
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/POSIX/"
@@ -127,16 +127,16 @@ if env["platform"] == "linux":
 if env["platform"] == "ios" and not env["ios_simulator"]:
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/POSIX/"
     if env["target"] in ("template_debug"):
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS/Debug-iphoneos/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS_Xcode1500/Debug-iphoneos/lib/"
     else:
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS/Release-iphoneos/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS_Xcode1500/Release-iphoneos/lib/"
 
 if env["platform"] == "ios" and env["ios_simulator"]:
     wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/POSIX/"
     if env["target"] in ("template_debug"):
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS/Debug-iphonesimulator/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS_Xcode1500/Debug-iphonesimulator/lib/"
     else:
-        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS/Release-iphonesimulator/lib/"
+        wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS_Xcode1500/Release-iphonesimulator/lib/"
 
 wwise_soundengine_sample_common_path = env["wwise_sdk"] + "/samples/SoundEngine/Common/"
 wwise_soundengine_common_include_path = wwise_sdk_headers_path + "AK/SoundEngine/Common/"

--- a/addons/Wwise/native/android/plugin/build.gradle.kts
+++ b/addons/Wwise/native/android/plugin/build.gradle.kts
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-    implementation("org.godotengine:godot:4.2.0.stable")
+    implementation("org.godotengine:godot:4.3.0.stable")
 }
 
 val cleanAssetsAddons by tasks.registering(Copy::class) {

--- a/addons/Wwise/native/src/core/utils.h
+++ b/addons/Wwise/native/src/core/utils.h
@@ -170,8 +170,6 @@ static const char* wwise_error_string(AKRESULT errcode)
 			return "AK_FileFormatMismatch";
 		case AK_NoDistinctListener:
 			return "AK_NoDistinctListener";
-		case AK_ACP_Error:
-			return "AK_ACP_Error";
 		case AK_ResourceInUse:
 			return "AK_ResourceInUse";
 		case AK_InvalidBankType:

--- a/addons/Wwise/native/src/core/wwise_gdextension.h
+++ b/addons/Wwise/native/src/core/wwise_gdextension.h
@@ -4,16 +4,10 @@
 #include "core/utils.h"
 #include "core/wwise_cookie.h"
 #include "core/wwise_io_hook.h"
-#include <godot_cpp/classes/display_server.hpp>
-#include <godot_cpp/classes/object.hpp>
-#include <godot_cpp/classes/project_settings.hpp>
-#include <godot_cpp/classes/ref_counted.hpp>
-#include <godot_cpp/classes/resource.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
 #include <AK/MusicEngine/Common/AkMusicEngine.h>
 #include <AK/SoundEngine/Common/AkCallback.h>
 #include <AK/SoundEngine/Common/AkMemoryMgr.h>
-#include <AK/SoundEngine/Common/AkModule.h>
+#include <AK/SoundEngine/Common/AkMemoryMgrModule.h>
 #include <AK/SoundEngine/Common/AkQueryParameters.h>
 #include <AK/SoundEngine/Common/AkSoundEngine.h>
 #include <AK/SoundEngine/Common/AkTypes.h>
@@ -22,6 +16,12 @@
 #include <AK/Tools/Common/AkAutoLock.h>
 #include <AK/Tools/Common/AkMonitorError.h>
 #include <AK/Tools/Common/AkObject.h>
+#include <godot_cpp/classes/display_server.hpp>
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/classes/resource.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
 
 #ifndef AK_OPTIMIZED
 #include <AK/Comm/AkCommunication.h>
@@ -142,8 +142,8 @@ public:
 			float transmission_loss_value, const Object* game_object, bool enable_diffraction,
 			bool enable_diffraction_on_boundary_edges);
 	bool remove_geometry(const Object* game_object);
-	bool set_geometry_instance(const Object* associated_geometry, const Transform3D& transform,
-			const Object* geometry_instance, const Object* associated_room);
+	bool set_geometry_instance(
+			const Object* associated_geometry, const Transform3D& transform, const Object* geometry_instance);
 	bool remove_geometry_instance(const Object* geometry_instance);
 	bool register_spatial_listener(const Object* game_object);
 	bool set_room(const Object* game_object, const unsigned int ak_aux_bus_id, const float reverb_level,

--- a/addons/Wwise/native/src/core/wwise_io_hook.cpp
+++ b/addons/Wwise/native/src/core/wwise_io_hook.cpp
@@ -236,17 +236,6 @@ void WwiseIOHook::BatchWrite(AkUInt32 in_u_num_transfers, BatchIoTransferItem* i
 	}
 }
 
-void WwiseIOHook::BatchCancel(AkUInt32 in_u_num_transfers, BatchIoTransferItem* in_p_transfer_items,
-		bool** io_ppb_cancel_all_transfers_for_this_file)
-{
-	for (int i = 0; i < (int)in_u_num_transfers; ++i)
-	{
-		BatchIoTransferItem io_transfer_item = in_p_transfer_items[i];
-		cancel(*(io_transfer_item.pFileDesc), *(io_transfer_item.pTransferInfo),
-				*io_ppb_cancel_all_transfers_for_this_file[i]);
-	}
-}
-
 AKRESULT WwiseIOHook::Close(AkFileDesc* in_file_desc)
 {
 	AKRESULT result = AK_Fail;

--- a/addons/Wwise/native/src/core/wwise_io_hook.h
+++ b/addons/Wwise/native/src/core/wwise_io_hook.h
@@ -40,8 +40,6 @@ public:
 	virtual void BatchOpen(AkUInt32 in_u_num_files, AkAsyncFileOpenData** in_pp_items) override;
 	virtual void BatchRead(AkUInt32 in_u_num_transfers, BatchIoTransferItem* in_p_transfer_items) override;
 	virtual void BatchWrite(AkUInt32 in_u_num_transfers, BatchIoTransferItem* in_p_transfer_items) override;
-	virtual void BatchCancel(AkUInt32 in_u_num_transfers, BatchIoTransferItem* in_p_transfer_items,
-			bool** io_ppb_cancel_all_transfers_for_this_file) override;
 	virtual AKRESULT Close(AkFileDesc* in_file_desc) override;
 	virtual AkUInt32 GetBlockSize(AkFileDesc& in_file_desc) override;
 	virtual void GetDeviceDesc(AkDeviceDesc& out_device_desc) override;

--- a/addons/Wwise/native/src/core/wwise_settings.cpp
+++ b/addons/Wwise/native/src/core/wwise_settings.cpp
@@ -23,6 +23,7 @@ WwiseSettings::WwiseSettings()
 
 void WwiseSettings::add_wwise_settings()
 {
+	// Common User Settings
 	add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "base_path", String("res://GeneratedSoundBanks"),
 			Variant::Type::STRING, PROPERTY_HINT_DIR, "res://GeneratedSoundBanks");
 	add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "startup_language", String("English(US)"), Variant::Type::STRING);
@@ -45,10 +46,8 @@ void WwiseSettings::add_wwise_settings()
 	// note(alex): this is not implemented:
 	add_setting(WWISE_COMMON_USER_SETTINGS_MAIN_OUTPUT_PATH + "channel_config/channel_mask", 0, Variant::Type::INT,
 			PROPERTY_HINT_ENUM, "NONE, Everything, SETUP_ALL_SPEAKERS");
-
 	add_setting(
 			WWISE_COMMON_USER_SETTINGS_MAIN_OUTPUT_PATH + "channel_config/number_of_channels", 0, Variant::Type::INT);
-
 	add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "streaming_look_ahead_ratio", 1.0f, Variant::Type::FLOAT,
 			PROPERTY_HINT_RANGE, "0.0, 1.0");
 	add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "sample_rate", 4, Variant::Type::INT, PROPERTY_HINT_ENUM,
@@ -56,24 +55,41 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(WWISE_COMMON_USER_SETTINGS_PATH + "number_of_refills_in_voice", 1, Variant::Type::INT,
 			PROPERTY_HINT_ENUM, "2, 4");
 
-	// Spatial Audio
-	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_sound_propagation_depth", 8.0f,
-			Variant::Type::FLOAT, PROPERTY_HINT_RANGE, "0.0,8.0");
+	// Spatial Audio Settings
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_sound_propagation_depth",
+			AK_MAX_SOUND_PROPAGATION_DEPTH, Variant::Type::FLOAT, PROPERTY_HINT_RANGE, "0.0,8.0");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "movement_threshold", 0.25f, Variant::Type::FLOAT,
+			PROPERTY_HINT_NONE, "");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "number_of_primary_rays", 35, Variant::Type::INT,
+			PROPERTY_HINT_NONE, "");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_reflection_order", 2, Variant::Type::INT,
+			PROPERTY_HINT_RANGE, "1,4");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_diffraction_order", 4, Variant::Type::INT,
+			PROPERTY_HINT_RANGE, "1,8");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_diffraction_paths", 8, Variant::Type::INT,
+			PROPERTY_HINT_NONE, "");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_global_reflection_paths", 0, Variant::Type::INT,
+			PROPERTY_HINT_NONE, "");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_emitter_room_aux_sends", 3, Variant::Type::INT);
 	add_setting(
-			WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "calc_emitter_virtual_position", true, Variant::Type::BOOL);
-	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "movement_threshold", 1.0f, Variant::Type::FLOAT,
-			PROPERTY_HINT_NONE, "");
-	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "number_of_primary_rays", 100, Variant::Type::INT,
-			PROPERTY_HINT_NONE, "");
-	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_reflection_order", 1.0f, Variant::Type::FLOAT,
-			PROPERTY_HINT_RANGE, "0.0,4.0");
+			WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "diffraction_on_reflections_order", 2, Variant::Type::INT);
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_diffraction_angle_degrees", 180.f,
+			Variant::Type::FLOAT, PROPERTY_HINT_NONE, "");
 	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_path_length", 10000.0f, Variant::Type::FLOAT,
 			PROPERTY_HINT_NONE, "");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "cpu_limit_percentage", 0.0f, Variant::Type::FLOAT,
+			PROPERTY_HINT_RANGE, "0.0,100.0");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "smoothing_constant_ms", 0.0f, Variant::Type::FLOAT,
+			PROPERTY_HINT_NONE, "");
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "load_balancing_spread", 1, Variant::Type::INT);
 	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "enable_geometric_diffraction_and_transmission", true,
 			Variant::Type::BOOL);
-	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "max_emitter_room_aux_sends", 0, Variant::Type::INT);
+	add_setting(
+			WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "calc_emitter_virtual_position", true, Variant::Type::BOOL);
+	add_setting(WWISE_COMMON_USER_SETTINGS_SPATIAL_AUDIO_PATH + "transmission_operation",
+			AkTransmissionOperation_Default, Variant::Type::INT, PROPERTY_HINT_ENUM, "Add, Multiply, Max");
 
-	// common advanced settings
+	// Common Advanced Settings
 	add_setting(WWISE_COMMON_ADVANCED_SETTINGS_PATH + "IO_memory_size", 2097152, Variant::Type::INT, PROPERTY_HINT_NONE,
 			"");
 	add_setting(WWISE_COMMON_ADVANCED_SETTINGS_PATH + "target_auto_stream_buffer_length_ms", 380, Variant::Type::INT);
@@ -87,18 +103,21 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(WWISE_COMMON_ADVANCED_SETTINGS_PATH + "debug_out_of_range_check_enabled", false, Variant::Type::BOOL);
 	add_setting(WWISE_COMMON_ADVANCED_SETTINGS_PATH + "debug_out_of_range_limit", 16.0f, Variant::Type::FLOAT);
 
-	// communication settings
+	// Communication Settings
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "discovery_broadcast_port", 24024, Variant::Type::INT);
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "command_port", 0, Variant::Type::INT);
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "initialize_system_comms", true, Variant::Type::BOOL);
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "network_name", "", Variant::Type::STRING);
 	add_setting(WWISE_COMMUNICATION_SETTINGS_PATH + "waapi_port", 8080, Variant::Type::INT);
 
+	// Windows Advanced Settings
+	add_setting(WWISE_WINDOWS_ADVANCED_SETTINGS_PATH + "max_system_audio_objects", 128, Variant::Type::INT);
+
 	// macOS advanced settings
 	add_setting(WWISE_MACOS_ADVANCED_SETTINGS_PATH + "audio_API", 3, Variant::Type::INT, PROPERTY_HINT_FLAGS,
 			"AVAudioEngine,AudioUnit");
 
-	// ios advanced settings
+	// iOS advanced settings
 	add_setting(WWISE_IOS_ADVANCED_SETTINGS_PATH + "audio_API", 3, Variant::Type::INT, PROPERTY_HINT_FLAGS,
 			"AVAudioEngine,AudioUnit");
 	add_setting(WWISE_IOS_ADVANCED_SETTINGS_PATH + "audio_session_category", 0, Variant::Type::INT, PROPERTY_HINT_ENUM,

--- a/addons/Wwise/native/src/core/wwise_settings.h
+++ b/addons/Wwise/native/src/core/wwise_settings.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AK/SpatialAudio/Common/AkSpatialAudio.h>
+#include <AK/SpatialAudio/Common/AkSpatialAudioTypes.h>
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>

--- a/addons/Wwise/native/src/scene/ak_geometry.cpp
+++ b/addons/Wwise/native/src/scene/ak_geometry.cpp
@@ -18,8 +18,6 @@ void AkGeometry::_bind_methods()
 	ClassDB::bind_method(D_METHOD("set_transmission_loss_value", "transmission_loss_value"),
 			&AkGeometry::set_transmission_loss_value);
 	ClassDB::bind_method(D_METHOD("get_transmission_loss_value"), &AkGeometry::get_transmission_loss_value);
-	ClassDB::bind_method(D_METHOD("set_associated_room", "associated_room"), &AkGeometry::set_associated_room);
-	ClassDB::bind_method(D_METHOD("get_associated_room"), &AkGeometry::get_associated_room);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_static", PROPERTY_HINT_NONE), "set_is_static", "get_is_static");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enable_diffraction", PROPERTY_HINT_NONE), "set_enable_diffraction",
@@ -30,8 +28,6 @@ void AkGeometry::_bind_methods()
 			"get_acoustic_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "transmission_loss_value", PROPERTY_HINT_NONE),
 			"set_transmission_loss_value", "get_transmission_loss_value");
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "associated_room", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "AkRoom"),
-			"set_associated_room", "get_associated_room");
 }
 
 void AkGeometry::_notification(int p_what, bool reversed)
@@ -115,11 +111,6 @@ bool AkGeometry::set_geometry(const MeshInstance3D* mesh_instance)
 		triangles.append(point_1);
 	}
 
-	if (!associated_room.is_empty())
-	{
-		room_node = get_node<Area3D>(associated_room);
-	}
-
 	Wwise* soundengine = Wwise::get_singleton();
 
 	bool geometry_result{};
@@ -128,8 +119,7 @@ bool AkGeometry::set_geometry(const MeshInstance3D* mesh_instance)
 	{
 		geometry_result = soundengine->set_geometry(vertices, triangles, acoustic_texture, transmission_loss_value,
 				this, enable_diffraction, enable_diffraction_on_boundary_edges);
-		instance_result =
-				soundengine->set_geometry_instance(this, get_global_transform(), geometry_instance, room_node);
+		instance_result = soundengine->set_geometry_instance(this, get_global_transform(), geometry_instance);
 	}
 
 	vertices.clear();
@@ -176,7 +166,3 @@ void AkGeometry::set_transmission_loss_value(float transmission_loss_value)
 }
 
 float AkGeometry::get_transmission_loss_value() const { return transmission_loss_value; }
-
-void AkGeometry::set_associated_room(const NodePath& associated_room) { this->associated_room = associated_room; }
-
-NodePath AkGeometry::get_associated_room() const { return associated_room; }

--- a/addons/Wwise/native/src/scene/ak_geometry.h
+++ b/addons/Wwise/native/src/scene/ak_geometry.h
@@ -28,9 +28,7 @@ private:
 	bool enable_diffraction_on_boundary_edges{};
 	Dictionary acoustic_texture{};
 	float transmission_loss_value{ 1.0f };
-	NodePath associated_room{};
 
-	Area3D* room_node{};
 	AABB aabb{};
 	PackedInt32Array indices{};
 
@@ -60,7 +58,4 @@ public:
 
 	void set_transmission_loss_value(float transmission_loss_value);
 	float get_transmission_loss_value() const;
-
-	void set_associated_room(const NodePath& associated_room);
-	NodePath get_associated_room() const;
 };

--- a/addons/Wwise/native/wwise.gdextension
+++ b/addons/Wwise/native/wwise.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "wwise_library_init"
-compatibility_minimum = "4.2"
+compatibility_minimum = "4.3"
 reloadable = false
 android_aar_plugin = true
 


### PR DESCRIPTION
Initial support for compiling with 24.1 SDK. Workflow improvement will be added in a follow-up PR.

- Updated Godot dependency from 4.2.0 to 4.3.0.
- Adjusted library paths for various platforms, support new toolchains.
- Removed deprecated `AK_ACP_Error` error.
- Removed deprecated `associated_room` parameter in `Wwise::set_geometry_instance`.
- Introduced additional spatial audio settings.
- Added `max_system_audio_objects` support for Windows advanced settings.
- Removed `WwiseIOHook::BatchCancel`.