### PR TITLE
Remove `playing_id` property from `AkEvent` nodes

### DIFF
--- a/addons/Wwise/native/src/core/types/wwise_event.cpp
+++ b/addons/Wwise/native/src/core/types/wwise_event.cpp
@@ -13,6 +13,9 @@ void WwiseEvent::_bind_methods()
 			D_METHOD("set_is_auto_bank_loaded", "is_auto_bank_loaded"), &WwiseEvent::set_is_auto_bank_loaded);
 	ClassDB::bind_method(D_METHOD("get_is_auto_bank_loaded"), &WwiseEvent::get_is_auto_bank_loaded);
 
+	ClassDB::bind_method(D_METHOD("set_playing_id", "playing_id"), &WwiseEvent::set_playing_id);
+	ClassDB::bind_method(D_METHOD("get_playing_id"), &WwiseEvent::get_playing_id);
+
 	ClassDB::bind_method(D_METHOD("_on_post_resource_init"), &WwiseEvent::_on_post_resource_init);
 	ClassDB::bind_method(D_METHOD("post", "game_object"), &WwiseEvent::post);
 	ClassDB::bind_method(D_METHOD("post_callback", "game_object", "flags", "cookie"), &WwiseEvent::post_callback);
@@ -29,6 +32,8 @@ void WwiseEvent::_bind_methods()
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bank_id"), "set_bank_id", "get_bank_id");
 	ADD_PROPERTY(
 			PropertyInfo(Variant::BOOL, "is_auto_bank_loaded"), "set_is_auto_bank_loaded", "get_is_auto_bank_loaded");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "playing_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE),
+			"set_playing_id", "get_playing_id");
 }
 
 void WwiseEvent::_notification(int p_what)
@@ -235,3 +240,10 @@ void WwiseEvent::set_is_auto_bank_loaded(bool p_is_auto_bank_loaded)
 }
 
 bool WwiseEvent::get_is_auto_bank_loaded() const { return is_auto_bank_loaded; }
+
+void WwiseEvent::set_playing_id(AkPlayingID p_playing_id)
+{
+	playing_id = p_playing_id;
+}
+
+AkPlayingID WwiseEvent::get_playing_id() const { return playing_id; }

--- a/addons/Wwise/native/src/core/types/wwise_event.h
+++ b/addons/Wwise/native/src/core/types/wwise_event.h
@@ -24,7 +24,7 @@ private:
 	bool is_in_user_defined_sound_bank{};
 	uint32_t bank_id{ AK_INVALID_UNIQUE_ID };
 	bool is_auto_bank_loaded{};
-	uint32_t playing_id;
+	uint32_t playing_id{ AK_INVALID_PLAYING_ID };
 
 	void _on_post_resource_init();
 	void load_auto_bank();
@@ -53,6 +53,9 @@ public:
 
 	void set_is_auto_bank_loaded(bool p_is_auto_bank_loaded);
 	bool get_is_auto_bank_loaded() const;
+
+	void set_playing_id(AkPlayingID p_playing_id);
+	AkPlayingID get_playing_id() const;
 
 #ifdef TOOLS_ENABLED
 	bool update_is_user_defined_soundbank()

--- a/addons/Wwise/native/src/scene/ak_event.cpp
+++ b/addons/Wwise/native/src/scene/ak_event.cpp
@@ -16,7 +16,6 @@ void AkEvent2D::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_trigger_on"), &AkEvent2D::get_trigger_on);
 	ClassDB::bind_method(D_METHOD("set_stop_on", "stop_on"), &AkEvent2D::set_stop_on);
 	ClassDB::bind_method(D_METHOD("get_stop_on"), &AkEvent2D::get_stop_on);
-	ClassDB::bind_method(D_METHOD("set_playing_id", "playing_id"), &AkEvent2D::set_playing_id);
 	ClassDB::bind_method(D_METHOD("get_playing_id"), &AkEvent2D::get_playing_id);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "WwiseEvent"), "set_event",
@@ -30,8 +29,6 @@ void AkEvent2D::_bind_methods()
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "interpolation_mode", PROPERTY_HINT_ENUM,
 						 "LOG3,SINE,LOG1,INVSCURVE,LINEAR,SCURVE,EXP1,SINERECIP,EXP3,LASTFADECURVE,CONSTANT"),
 			"set_interpolation_mode", "get_interpolation_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "playing_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE),
-			"set_playing_id", "get_playing_id");
 
 	ADD_ALL_AK_EVENT_SIGNALS;
 }
@@ -99,11 +96,11 @@ void AkEvent2D::post_event()
 
 	if (callback_type)
 	{
-		playing_id = event->post_callback(this, (AkUtils::AkCallbackType)callback_type, cookie);
+		event->post_callback(this, (AkUtils::AkCallbackType)callback_type, cookie);
 	}
 	else
 	{
-		playing_id = event->post(this);
+		event->post(this);
 	}
 }
 
@@ -151,9 +148,15 @@ void AkEvent2D::set_stop_on(AkUtils::GameEvent stop_on) { this->stop_on = stop_o
 
 AkUtils::GameEvent AkEvent2D::get_stop_on() const { return stop_on; }
 
-void AkEvent2D::set_playing_id(AkPlayingID p_playing_id) { playing_id = p_playing_id; }
+AkPlayingID AkEvent2D::get_playing_id() const
+{
+	if (event.is_null())
+	{
+		return AK_INVALID_PLAYING_ID;
+	}
 
-AkPlayingID AkEvent2D::get_playing_id() const { return playing_id; }
+	return event->get_playing_id();
+}
 
 void AkEvent3D::_bind_methods()
 {
@@ -176,7 +179,6 @@ void AkEvent3D::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_is_environment_aware"), &AkEvent3D::get_is_environment_aware);
 	ClassDB::bind_method(D_METHOD("set_room_id", "room_id"), &AkEvent3D::set_room_id);
 	ClassDB::bind_method(D_METHOD("get_room_id"), &AkEvent3D::get_room_id);
-	ClassDB::bind_method(D_METHOD("set_playing_id", "playing_id"), &AkEvent3D::set_playing_id);
 	ClassDB::bind_method(D_METHOD("get_playing_id"), &AkEvent3D::get_playing_id);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "WwiseEvent"), "set_event",
@@ -194,8 +196,6 @@ void AkEvent3D::_bind_methods()
 			"get_is_environment_aware");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "room_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_room_id",
 			"get_room_id");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "playing_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE),
-			"set_playing_id", "get_playing_id");
 
 	ADD_ALL_AK_EVENT_SIGNALS;
 }
@@ -293,11 +293,11 @@ void AkEvent3D::post_event()
 
 	if (callback_type)
 	{
-		playing_id = event->post_callback(this, (AkUtils::AkCallbackType)callback_type, cookie);
+		event->post_callback(this, (AkUtils::AkCallbackType)callback_type, cookie);
 	}
 	else
 	{
-		playing_id = event->post(this);
+		event->post(this);
 	}
 }
 
@@ -360,6 +360,12 @@ void AkEvent3D::set_room_id(uint64_t room_id) { this->room_id = room_id; }
 
 uint64_t AkEvent3D::get_room_id() const { return room_id; }
 
-void AkEvent3D::set_playing_id(AkPlayingID p_playing_id) { playing_id = p_playing_id; }
+AkPlayingID AkEvent3D::get_playing_id() const
+{
+	if (event.is_null())
+	{
+		return AK_INVALID_PLAYING_ID;
+	}
 
-AkPlayingID AkEvent3D::get_playing_id() const { return playing_id; }
+	return event->get_playing_id();
+}

--- a/addons/Wwise/native/src/scene/ak_event.h
+++ b/addons/Wwise/native/src/scene/ak_event.h
@@ -22,7 +22,6 @@ protected:
 
 private:
 	Ref<WwiseEvent> event;
-	AkPlayingID playing_id = AK_INVALID_PLAYING_ID;
 	unsigned int stop_fade_time{};
 	AkUtils::AkCurveInterpolation interpolation_mode = AkUtils::AkCurveInterpolation::AK_CURVE_LINEAR;
 	int callback_type{};
@@ -62,7 +61,6 @@ public:
 	void set_stop_on(AkUtils::GameEvent stop_on);
 	AkUtils::GameEvent get_stop_on() const;
 
-	void set_playing_id(AkPlayingID p_playing_id);
 	AkPlayingID get_playing_id() const;
 };
 
@@ -75,7 +73,6 @@ protected:
 
 private:
 	Ref<WwiseEvent> event;
-	AkPlayingID playing_id = AK_INVALID_PLAYING_ID;
 	unsigned int stop_fade_time{};
 	AkUtils::AkCurveInterpolation interpolation_mode = AkUtils::AkCurveInterpolation::AK_CURVE_LINEAR;
 	bool is_environment_aware{};
@@ -127,6 +124,5 @@ public:
 	void set_room_id(uint64_t room_id);
 	uint64_t get_room_id() const;
 
-	void set_playing_id(AkPlayingID p_playing_id);
 	AkPlayingID get_playing_id() const;
 };


### PR DESCRIPTION
The `AkEvent` nodes should get the current `AkPlayingID` directly from the exposed `WwiseEvent` object.