### PR TITLE
Fix Wwise Picker positioning

### DIFF
--- a/addons/Wwise/native/src/editor/ak_wwise_inspector_picker.cpp
+++ b/addons/Wwise/native/src/editor/ak_wwise_inspector_picker.cpp
@@ -59,13 +59,13 @@ void AkWwiseInspectorPicker::open(WwiseObjectType p_wwise_object_type, Point2i p
 	if (saved_size != Rect2())
 	{
 		set_min_size(min_size);
-		popup_on_parent(saved_size);
+		popup(saved_size);
 	}
 	else
 	{
 		Rect2i rect = Rect2i(Point2i(p_pos.x - min_size.x, p_pos.y), min_size);
 		set_min_size(min_size);
-		popup_on_parent(rect);
+		popup(rect);
 	}
 
 	search_text->set_placeholder("Search...");


### PR DESCRIPTION
Fixed an issue with the Wwise picker positioning. Previously, the `popup_on_parent` method caused the picker to open with an unintended Y-axis shift due to position offsets being saved and retrieved incorrectly.

This update replaces `popup_on_parent` with the `popup` method, ensuring the picker opens at the correct position.