### PR TITLE
Only export extension init symbol on Linux

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -300,6 +300,7 @@ jobs:
           rm -r ./addons/Wwise/native/src
           rm -r ./addons/Wwise/native/vs2022
           rm -r ./addons/Wwise/native/android
+          rm -r ./addons/Wwise/native/linux
           rm -r ./addons/Wwise/native/doc_classes
           rm ./addons/Wwise/native/SConstruct
           rm ./LICENSE

--- a/addons/Wwise/native/SConstruct
+++ b/addons/Wwise/native/SConstruct
@@ -499,7 +499,14 @@ elif env["platform"] == "linux":
 
     env.Append(CCFLAGS=["-fPIC", "-Wwrite-strings"])
     env.Append(CXXFLAGS=["-std=c++20"])
-    env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])
+    symbols_file = env.File("linux/symbols-extension.map")
+    env.Append(
+    LINKFLAGS=[
+        "-Wl,-R,'$$ORIGIN'",
+        "-Wl,--no-undefined,--version-script=" + symbols_file.abspath,
+        "-static-libgcc",
+        "-static-libstdc++",
+    ])
 
 # iOS build settings
 elif env["platform"] == "ios":

--- a/addons/Wwise/native/linux/symbols-extension.map
+++ b/addons/Wwise/native/linux/symbols-extension.map
@@ -1,0 +1,6 @@
+{
+    global:
+        wwise_library_init;
+    local:
+        *;
+};


### PR DESCRIPTION
This fixes a crash that occurs when the extension is used alongside other extensions. Same issue that was experienced 
in this project: https://github.com/godotengine/webrtc-native/issues/127