### PR TITLE
Remove build profile files from artifact

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -305,6 +305,8 @@ jobs:
           rm -r ./addons/Wwise/native/linux
           rm -r ./addons/Wwise/native/doc_classes
           rm ./addons/Wwise/native/SConstruct
+          rm ./addons/Wwise/native/build_profile_editor.json
+          rm ./addons/Wwise/native/build_profile_runtime.json
           rm ./LICENSE
           rm ./README.md
           rm .gitattributes


### PR DESCRIPTION
Removes `build_profile_editor.json` and `build_profile_runtime.json` from the final artifact in GitHub Actions.