### PR TITLE
Disconnect Area Signals in AkRoom node

### DIFF
--- a/addons/Wwise/native/src/scene/ak_room.cpp
+++ b/addons/Wwise/native/src/scene/ak_room.cpp
@@ -74,6 +74,9 @@ void AkRoom::_exit_tree()
 	{
 		soundengine->remove_room(this);
 	}
+
+	disconnect("area_entered", callable_mp(this, &AkRoom::_on_area_entered));
+	disconnect("area_exited", callable_mp(this, &AkRoom::_on_area_exited));
 }
 
 void AkRoom::_on_area_entered(const Area3D* area)


### PR DESCRIPTION
Fixes a crash when reparenting the AkRoom node.