### PR TITLE
Fix set_listeners bug

### DIFF
--- a/addons/Wwise/native/src/core/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/core/wwise_gdextension.cpp
@@ -399,8 +399,8 @@ bool Wwise::set_listeners(Node* emitter, Node* listener)
 	AkGameObjectID listener_id = get_ak_game_object_id(listener);
 	pre_game_object_api_call(listener, listener_id);
 
-	static const int num_listeners_for_emitter = 1;
-	static const AkGameObjectID listeners_for_emitter[num_listeners_for_emitter] = { listener_id };
+	const int num_listeners_for_emitter = 1;
+	const AkGameObjectID listeners_for_emitter[num_listeners_for_emitter] = { listener_id };
 	return ERROR_CHECK(AK::SoundEngine::SetListeners(emitter_id, listeners_for_emitter, 1));
 }
 


### PR DESCRIPTION
This is a fairly straight-forward fix for an issue with the set_listeners function. Currently, only the first time this function is called will result in the expected behavior. For subsequent calls, the target listener is ignored, and instead it functions as if you passed in the same listener from the first call. 

The fix for this was to remove the static keywords used in that function. If those variables are both static and const, their contents are carried over between function calls and won't be allowed to change.

With this fix in place, multiple calls to set_listeners results in the expected behavior. This can be viewed in the Wwise profiler via the Emitter-Listener relationship tab. 