### PR TITLE
Update upload-addon step to ubuntu-22.04

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -203,7 +203,7 @@ jobs:
           path: addons/Wwise/native/lib
 
   upload-addon:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: [build-all]
     name: Addon
     steps:


### PR DESCRIPTION
Updated the 'upload-addon' step in the GitHub Actions workflow to run on ubuntu-22.04 instead of the deprecated ubuntu-20.04.