### PR TITLE
Remove redundant game object unregistration from `AkListener::_exit_tree`

### DIFF
--- a/addons/Wwise/native/src/scene/ak_listener.cpp
+++ b/addons/Wwise/native/src/scene/ak_listener.cpp
@@ -35,8 +35,6 @@ void AkListener2D::_exit_tree()
 		{
 			soundengine->remove_default_listener(this);
 		}
-
-		soundengine->unregister_game_obj(this);
 	}
 }
 
@@ -89,8 +87,6 @@ void AkListener3D::_exit_tree()
 		{
 			soundengine->remove_default_listener(this);
 		}
-
-		soundengine->unregister_game_obj(this);
 	}
 }
 


### PR DESCRIPTION
The calls to `soundengine->unregister_game_obj(this)` in both `AkListener2D::_exit_tree()` and `AkListener3D::_exit_tree()` have been removed. These unregistration steps are handled by the `AkGameObject` helper nodes, making the explicit calls unnecessary.