### PR TITLE
Remove undefined Wwise settings from Project Settings

### DIFF
--- a/addons/Wwise/native/src/core/wwise_settings.h
+++ b/addons/Wwise/native/src/core/wwise_settings.h
@@ -5,6 +5,7 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
@@ -18,10 +19,12 @@ protected:
 
 private:
 	static WwiseSettings* singleton;
+	HashSet<StringName> defined_settings;
 
 	void add_wwise_settings();
 	void add_setting(const StringName& name, const Variant& default_value, Variant::Type type,
 			PropertyHint hint = PROPERTY_HINT_NONE, const StringName& hint_string = "");
+	void remove_undefined_settings();
 
 public:
 	struct MainOutputSettings


### PR DESCRIPTION
Wwise settings that are removed from the codebase (i.e. due to an update) will now be automatically removed from the user's `project.godot` file upon initialization, rather than persisting indefinitely as orphaned keys.