### PR TITLE
Updates to support banks as separate files (for educational/gamejam content)

### DIFF
--- a/addons/Wwise/native/src/core/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/core/wwise_gdextension.cpp
@@ -228,8 +228,10 @@ void Wwise::init()
 		UtilityFunctions::push_error("WwiseGodot: Failed to get the SoundBank directory for the current platform.");
 	}
 
-	String banks_path = vformat("%s/%s/", root_output_path, banks_platform_suffix);
-	set_banks_path(banks_path);
+	if (! static_cast<bool>(project_settings->get_setting(project_settings->advanced_settings.custom_banks_path))) {
+		String banks_path = vformat("%s/%s/", root_output_path, banks_platform_suffix);
+		set_banks_path(banks_path);
+	}
 
 	String startup_language = project_settings->get_setting(project_settings->common_user_settings.startup_language);
 	set_current_language(startup_language);

--- a/addons/Wwise/native/src/core/wwise_settings.cpp
+++ b/addons/Wwise/native/src/core/wwise_settings.cpp
@@ -60,6 +60,8 @@ WwiseSettings::WwiseSettings()
 	spatial_audio_settings.transmission_operation = "wwise/common_user_settings/spatial_audio/transmission_operation";
 
 	// Advanced Settings
+	advanced_settings.export_banks = "wwise/common_advanced_settings/export_banks";
+	advanced_settings.custom_banks_path = "wwise/common_advanced_settings/custom_banks_path";
 	advanced_settings.io_memory_size = "wwise/common_advanced_settings/IO_memory_size";
 	advanced_settings.target_auto_stream_buffer_length_ms =
 			"wwise/common_advanced_settings/target_auto_stream_buffer_length_ms";
@@ -232,6 +234,8 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(common_user_settings.main_output.number_of_channels, 0, Variant::Type::INT);
 
 	// Advanced Settings
+	add_setting(advanced_settings.export_banks, true, Variant::Type::BOOL);
+	add_setting(advanced_settings.custom_banks_path, false, Variant::Type::BOOL);
 	add_setting(advanced_settings.io_memory_size, 2097152, Variant::Type::INT);
 	add_setting(advanced_settings.target_auto_stream_buffer_length_ms, 380, Variant::Type::INT);
 	add_setting(advanced_settings.use_stream_cache, false, Variant::Type::BOOL);

--- a/addons/Wwise/native/src/core/wwise_settings.h
+++ b/addons/Wwise/native/src/core/wwise_settings.h
@@ -77,6 +77,8 @@ public:
 
 	struct AdvancedSettings
 	{
+		StringName export_banks;
+		StringName custom_banks_path;
 		StringName io_memory_size;
 		StringName target_auto_stream_buffer_length_ms;
 		StringName use_stream_cache;

--- a/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.cpp
+++ b/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.cpp
@@ -233,7 +233,9 @@ void AkEditorExportPlugin::_export_begin(
 			continue;
 		}
 
-		add_files_recursive(dir, platform_banks_path);
+		if (settings->get_setting(settings->advanced_settings.export_banks)) {
+			add_files_recursive(dir, platform_banks_path);
+		}
 
 		String library_path = get_platform_library_path(gdextension_config, it->first, p_features, p_is_debug);
 		String dsp_path = library_path.get_base_dir().path_join("DSP");


### PR DESCRIPTION
Added 2 configuration variables:
- Export banks: set to false to omit banks when exporting the godot project
- Custom banks path: if set to true, Wwise.init() will not set the banks path