### PR TITLE
Prevent editor crash during shutdown caused by AkEditorUtils

### DIFF
--- a/addons/Wwise/native/src/editor/ak_editor_utils.cpp
+++ b/addons/Wwise/native/src/editor/ak_editor_utils.cpp
@@ -1,6 +1,18 @@
 #include "ak_editor_utils.h"
 
-Ref<Texture2D> AkEditorUtils::icon_cache[2][(int)WwiseObjectType::Max] = {};
+AkEditorUtils* AkEditorUtils::singleton = nullptr;
+
+AkEditorUtils::AkEditorUtils()
+{
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+}
+
+AkEditorUtils::~AkEditorUtils()
+{
+	ERR_FAIL_COND(singleton != this);
+	singleton = nullptr;
+}
 
 Ref<Texture2D> AkEditorUtils::get_editor_icon(const WwiseObjectType p_type)
 {

--- a/addons/Wwise/native/src/editor/ak_editor_utils.h
+++ b/addons/Wwise/native/src/editor/ak_editor_utils.h
@@ -16,10 +16,14 @@ protected:
 	static void _bind_methods() {};
 
 private:
-	static Ref<Texture2D> icon_cache[2][(int)WwiseObjectType::Max];
+	static AkEditorUtils* singleton;
+	Ref<Texture2D> icon_cache[2][(int)WwiseObjectType::Max];
 
 public:
-	static Ref<Texture2D> get_editor_icon(const WwiseObjectType p_type);
-	static String get_icon_name(const WwiseObjectType p_type);
-	static String get_theme_folder(bool dark_mode);
+	AkEditorUtils();
+	~AkEditorUtils();
+	static AkEditorUtils* get_singleton() { return singleton; };
+	Ref<Texture2D> get_editor_icon(const WwiseObjectType p_type);
+	String get_icon_name(const WwiseObjectType p_type);
+	String get_theme_folder(bool dark_mode);
 };

--- a/addons/Wwise/native/src/editor/ak_wwise_tree.cpp
+++ b/addons/Wwise/native/src/editor/ak_wwise_tree.cpp
@@ -139,7 +139,8 @@ Variant AkWwiseTree::_get_drag_data(const Vector2& p_at_position)
 		{
 			Button* button = memnew(Button);
 			button->set_text(wwise_tree_item->get_name());
-			button->set_button_icon(AkEditorUtils::get_editor_icon(wwise_tree_item->get_object_type()));
+			button->set_button_icon(
+					AkEditorUtils::get_singleton()->get_editor_icon(wwise_tree_item->get_object_type()));
 
 			Control* control = memnew(Control);
 			control->add_child(button);

--- a/addons/Wwise/native/src/editor/ak_wwise_tree_item.cpp
+++ b/addons/Wwise/native/src/editor/ak_wwise_tree_item.cpp
@@ -26,7 +26,7 @@ void AkWwiseTreeItem::init(AkWwiseTree* p_tree, TreeItem* p_tree_item, const Str
 
 	tree_item->set_text(0, display_name);
 	tree_item->set_meta("ak_wwise_tree_item", this);
-	tree_item->set_icon(0, AkEditorUtils::get_editor_icon(p_type));
+	tree_item->set_icon(0, AkEditorUtils::get_singleton()->get_editor_icon(p_type));
 }
 
 void AkWwiseTreeItem::set_name(const String& p_name) { display_name = p_name; }

--- a/addons/Wwise/native/src/editor/properties/ak_wwise_editor_property.cpp
+++ b/addons/Wwise/native/src/editor/properties/ak_wwise_editor_property.cpp
@@ -42,7 +42,7 @@ String AkWwiseEditorProperty::get_button_placeholder_text() const { return "Defa
 
 Ref<Texture2D> AkWwiseEditorProperty::get_property_icon() const
 {
-	return AkEditorUtils::get_editor_icon(get_wwise_object_type());
+	return AkEditorUtils::get_singleton()->get_editor_icon(get_wwise_object_type());
 }
 
 WwiseObjectType AkWwiseEditorProperty::get_wwise_object_type() const { return WwiseObjectType::Project; }

--- a/addons/Wwise/native/src/wwise_gdextension_main.cpp
+++ b/addons/Wwise/native/src/wwise_gdextension_main.cpp
@@ -79,6 +79,7 @@ static WwiseSettings* wwise_settings;
 static AkUtils* ak_utils;
 #if defined(TOOLS_ENABLED)
 static WwiseProjectDatabase* wwise_project_database;
+static AkEditorUtils* ak_editor_utils;
 #endif
 
 void register_wwise_types(ModuleInitializationLevel p_level)
@@ -130,6 +131,8 @@ void register_wwise_types(ModuleInitializationLevel p_level)
 		ClassDB::register_class<WwiseBrowser>();
 		EditorPlugins::add_by_type<WwiseBrowser>();
 		ClassDB::register_class<AkEditorUtils>();
+		ak_editor_utils = memnew(AkEditorUtils);
+		Engine::get_singleton()->register_singleton("AkEditorUtils", AkEditorUtils::get_singleton());
 #endif
 #endif
 	}


### PR DESCRIPTION
Automated backport to `wwise_v2024.1`, triggered by PR #201.