### PR TITLE
Add experimental Web target support via Emscripten

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -26,6 +26,7 @@ env:
   GODOT_ENGINE_VERSION: "4.3"
   BUILD_PROFILE_EDITOR: "build_profile_editor.json"
   BUILD_PROFILE_RUNTIME: "build_profile_runtime.json"
+  EM_VERSION: 4.0.20
 
 jobs:
   build-all:
@@ -73,6 +74,12 @@ jobs:
             debug-flags-arm32: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm32
             release-flags-arm32: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm32
             artifact-name: android-lib
+
+          - name: Web
+            os: "ubuntu-22.04"
+            sdk-platform: web
+            scons-platform: web
+            artifact-name: web
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,6 +106,13 @@ jobs:
         with:
           ndk-version: r23c
           link-to-sdk: true
+
+      - name: Setup Emscripten 
+        if: matrix.sdk-platform == 'web'
+        uses: emscripten-core/setup-emsdk@v15
+        with:
+          version: ${{ env.EM_VERSION }}
+          no-cache: true
 
       - name: Wwise SDK cache
         id: cache-wwise-sdk
@@ -159,9 +173,14 @@ jobs:
         if: runner.os == 'Linux' && matrix.sdk-platform == 'android' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
         run: |
             python ./addons/Wwise/native/tools/wwise-dl.py --user ${{ secrets.AK_USER }} --pass ${{ secrets.AK_PASS }} ${{ env.WWISE_VERSION }}.${{ env.WWISE_BUILD }} Android --plugins Auro ConvolutionReverb iZotope McDSP Reflect SoundSeed SoundSeedGrain ResonanceAudio Motion ASIO AkChannelRouter MasteringSuite CrankcaseAudioREVModelPlayer Impacter --output ./addons/Wwise/native/wwise_sdk/
+      
+      - name: Prepare SDK (Web)
+        if: runner.os == 'Linux' && matrix.sdk-platform == 'web' && steps.cache-wwise-sdk.outputs.cache-hit != 'true'
+        run: |
+            python ./addons/Wwise/native/tools/wwise-dl.py --user ${{ secrets.AK_USER }} --pass ${{ secrets.AK_PASS }} ${{ env.WWISE_VERSION }}.${{ env.WWISE_BUILD }} Emscripten --plugins ConvolutionReverb Reflect SoundSeed SoundSeedGrain MasteringSuite Impacter --output ./addons/Wwise/native/wwise_sdk/
 
       - name: Compile editor library
-        if: matrix.sdk-platform != 'android' && matrix.sdk-platform != 'ios'
+        if: matrix.sdk-platform != 'android' && matrix.sdk-platform != 'ios' && matrix.sdk-platform != 'web'
         shell: bash
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
@@ -173,7 +192,7 @@ jobs:
           cd ../../../
 
       - name: Compile template_debug library
-        if: matrix.sdk-platform != 'android'
+        if: matrix.sdk-platform != 'android' && matrix.sdk-platform != 'web'
         shell: bash
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
@@ -184,7 +203,7 @@ jobs:
           cd ../../../
 
       - name: Compile template_release library
-        if: matrix.sdk-platform != 'android'
+        if: matrix.sdk-platform != 'android' && matrix.sdk-platform != 'web'
         shell: bash
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
@@ -209,6 +228,37 @@ jobs:
           cd ../android
           chmod +x ./gradlew
           ./gradlew assemble -PWWISE_SDK="$WWISESDK" -Pprecision=${{ env.BUILD_PRECISION }}
+
+      - name: Compile Web libraries
+        if: matrix.sdk-platform == 'web'
+        shell: bash
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+          SCONS_CACHE_LIMIT: 7168
+        run: |
+          cd addons/Wwise/native
+
+          for threads in no yes; do
+            scons platform=${{ matrix.scons-platform }} \
+              target=template_debug \
+              wwise_config=profile \
+              wwise_sdk=wwise_sdk/SDK \
+              build_profile=${{ env.BUILD_PROFILE_RUNTIME }} \
+              precision=${{ env.BUILD_PRECISION }} \
+              plugins=reflect,convolution,soundseed_grain,soundseed_air,mastering_suite \
+              threads=$threads
+
+            scons platform=${{ matrix.scons-platform }} \
+              target=template_release \
+              wwise_config=release \
+              wwise_sdk=wwise_sdk/SDK \
+              build_profile=${{ env.BUILD_PROFILE_RUNTIME }} \
+              precision=${{ env.BUILD_PRECISION }} \
+              plugins=reflect,convolution,soundseed_grain,soundseed_air,mastering_suite \
+              threads=$threads
+          done
+
+          cd ../../../
 
       - name: Upload libs
         uses: actions/upload-artifact@v4
@@ -255,6 +305,10 @@ jobs:
           if [ -d ios${{ env.PRECISION_SUFFIX }} ]; then
             mv ios${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
             rm -r ios${{ env.PRECISION_SUFFIX }}
+          fi
+          if [ -d web${{ env.PRECISION_SUFFIX }} ]; then
+            mv web${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            rm -r web${{ env.PRECISION_SUFFIX }}
           fi
 
       - name: Clean up addon

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Welcome! This repository provides an integration of [Audiokinetic's Wwise audio 
 
 ## Features
 
-* [GDExtension](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/what_is_gdextension.html)-based Wwise wrapper library for Windows, macOS, Linux, Android and iOS.
-* Multi-platform builds with SCons (Windows, macOS, Linux, iOS) and Gradle/CMake (Android). A Visual Studio 2022 solution is provided for Windows development.
+* [GDExtension](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/what_is_gdextension.html)-based Wwise wrapper library for Windows, macOS, Linux, Android, iOS and Web (experimental).
+* Multi-platform builds with SCons (Windows, macOS, Linux, iOS, Web) and Gradle/CMake (Android). A Visual Studio 2022 solution is provided for Windows development.
 * Wwise profiler connection available in GDExtension debug and profile builds.
 * Stream manager uses the default blocking I/O implementation and it can be extended to use custom I/O devices.
 * Custom Godot Nodes: AkEvent3D, AkEvent2D, AkBank, AkListener3D, AkListener2D, AkState, AkSwitch, AkEnvironment, AkGeometry, AkRoom, AkPortal, AkEarlyReflections.
@@ -20,13 +20,13 @@ Welcome! This repository provides an integration of [Audiokinetic's Wwise audio 
 * A Wwise IDs generator tool is embedded in the Wwise Browser.
 * Per-platform Wwise configurations in the Godot Project Settings.
 * In-engine documentation: quick access to reference materials and code snippets in the Godot Editor
-* Plugin Support: Plugin detection and export across all platforms, including custom plugin support.
+* Plugin Support: Plugin detection and export across desktop and mobile platforms, including custom plugin support.
 
 ## Getting Started
 
-If you're a game developer who wants to integrate Wwise into your Godot project, go to the [Releases](https://github.com/alessandrofama/wwise-godot-integration/releases) page to download the integration and check out the [Getting Started](https://github.com/alessandrofama/wwise-godot-integration/wiki/Getting-Started-(24.1)) guide.
+If you're a game developer who wants to integrate Wwise into your Godot project, go to the [Releases](https://github.com/alessandrofama/wwise-godot-integration/releases) page to download the integration and check out the [Getting Started](https://github.com/alessandrofama/wwise-godot-integration/wiki/Getting-Started) guide.
 
-If you would like to modify the GDExtension code or build it yourself, refer to the [Building the GDExtension Library tutorial](https://github.com/alessandrofama/wwise-godot-integration/wiki/Building-the-GDExtension-Library-(24.1)) for detailed build instructions.
+If you would like to modify the GDExtension code or build it yourself, refer to the [Building the GDExtension Library tutorial](https://github.com/alessandrofama/wwise-godot-integration/wiki/Building-the-GDExtension-Library) for detailed build instructions.
 
 ## Documentation
 

--- a/addons/Wwise/native/SConstruct
+++ b/addons/Wwise/native/SConstruct
@@ -70,6 +70,24 @@ def make_doc_source(target, source, env):
 
     g.close()
 
+def generate_web_plugin_registration(target_file, env):
+    os.makedirs(os.path.dirname(target_file), exist_ok=True)
+    with open(target_file, "w") as f:
+        f.write("/* THIS FILE IS GENERATED. DO NOT EDIT */\n")
+        f.write("#pragma once\n\n")
+        
+        if env["platform"] in ["web"]:
+            f.write("#include <AK/AkPlatforms.h>\n")
+            f.write("#include <AK/SoundEngine/Common/AkTypes.h>\n")
+            f.write("#include <AK/SoundEngine/Common/IAkPlugin.h>\n\n")
+            
+            for plugin_name in env.get("plugins", []):
+                if plugin_name in WWISE_WEB_PLUGINS_MAP:
+                    f.write(f"// {plugin_name}\n")
+                    for header in WWISE_WEB_PLUGINS_MAP[plugin_name]["headers"]:
+                        f.write(f"#include {header}\n")
+                    f.write("\n")
+
 def copy_plugins_with_skip(src_path, dst_path, file_extension, skip_plugins):
     if not os.path.exists(src_path):
         return
@@ -164,6 +182,36 @@ skip_plugins = [
     "gme"
 ]
 
+WWISE_WEB_PLUGINS_MAP = {
+    "reflect": {
+        "headers": ["<AK/Plugin/AkReflectFXFactory.h>"],
+        "libs": ["AkReflectFX"]
+    },
+    "convolution": {
+        "headers": ["<AK/Plugin/AkConvolutionReverbFXFactory.h>"],
+        "libs": ["AkConvolutionReverbFX"]
+    },
+    "soundseed_grain": {
+        "headers": ["<AK/Plugin/AkSoundSeedGrainSourceFactory.h>"],
+        "libs": ["AkSoundSeedGrainSource"]
+    },
+    "soundseed_air": {
+        "headers": [
+            "<AK/Plugin/AkSoundSeedWindSourceFactory.h>", 
+            "<AK/Plugin/AkSoundSeedWooshSourceFactory.h>"
+        ],
+        "libs": ["AkSoundSeedWindSource", "AkSoundSeedWooshSource"]
+    },
+    "impacter": {
+        "headers": ["<AK/Plugin/AkImpacterSourceFactory.h>"],
+        "libs": ["AkImpacterSource"]
+    },
+    "mastering_suite": {
+        "headers": ["<AK/Plugin/MasteringSuiteFXFactory.h>"],
+        "libs": ["MasteringSuiteFX"]
+    }
+}
+
 env = SConscript("godot-cpp/SConstruct")
 opts = Variables([], ARGUMENTS)
 
@@ -184,7 +232,6 @@ opts.Add(
         "",
         [
             "reflect",
-            "motion",
             "convolution",
             "soundseed_grain",
             "soundseed_air",
@@ -281,6 +328,23 @@ if env["platform"] == "ios" and env["ios_simulator"]:
         wwise_sdk_libs_path = env["wwise_sdk"] + "/iOS_Xcode1500/Release-iphonesimulator/lib/"
         wwise_sdk_plugins_path = env["wwise_sdk"] + "/iOS_Xcode1500/Release-iphonesimulator/lib/"
 
+if env["platform"] == "web":
+    wwise_soundengine_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/POSIX/"
+    wwise_emscripten_sample_path = env["wwise_sdk"] + "/samples/SoundEngine/Emscripten/"
+    
+    # We can only support Emscripten_st at this moment.
+    emscripten_arch = "Emscripten_st" if env.get("threads", False) else "Emscripten_st"
+    
+    if env["wwise_config"] == "debug":
+        wwise_sdk_libs_path = env["wwise_sdk"] + f"/{emscripten_arch}/Debug/lib/"
+        wwise_sdk_plugins_path = env["wwise_sdk"] + f"/{emscripten_arch}/Debug/lib/"
+    elif env["wwise_config"] == "profile":
+        wwise_sdk_libs_path = env["wwise_sdk"] + f"/{emscripten_arch}/Profile/lib/"
+        wwise_sdk_plugins_path = env["wwise_sdk"] + f"/{emscripten_arch}/Profile/lib/"
+    else:
+        wwise_sdk_libs_path = env["wwise_sdk"] + f"/{emscripten_arch}/Release/lib/"
+        wwise_sdk_plugins_path = env["wwise_sdk"] + f"/{emscripten_arch}/Release/lib/"
+
 wwise_soundengine_sample_common_path = env["wwise_sdk"] + "/samples/SoundEngine/Common/"
 wwise_soundengine_common_include_path = wwise_sdk_headers_path + "AK/SoundEngine/Common/"
 wwise_soundengine_project_database_path = env["wwise_sdk"] + "/samples/WwiseProjectDatabase/"
@@ -319,33 +383,6 @@ wwise_plugins_library = [
     "AkSpatialAudio",
     "Ak3DAudioBedMixerFX"
 ]
-
-## Plugins
-if "reflect" in env["plugins"]:
-    wwise_plugins_library.append("AkReflectFX")
-    env.Append(CPPDEFINES=["AK_REFLECT"])
-
-if "convolution" in env["plugins"]:
-    wwise_plugins_library.append("AkConvolutionReverbFX")
-    env.Append(CPPDEFINES=["AK_CONVOLUTION"])
-
-if "soundseed_grain" in env["plugins"]:
-    wwise_plugins_library.append("AkSoundSeedGrainSource")
-    env.Append(CPPDEFINES=["AK_SOUNDSEED_GRAIN"])
-
-if "soundseed_air" in env["plugins"]:
-    wwise_plugins_library.append(
-        ["AkSoundSeedWindSource", "AkSoundSeedWooshSource"]
-    )
-    env.Append(CPPDEFINES=["AK_SOUNDSEED_AIR"])
-
-if "impacter" in env["plugins"]:
-    wwise_plugins_library.append("AkImpacterSource")
-    env.Append(CPPDEFINES=["AK_IMPACTER"])
-
-if "mastering_suite" in env["plugins"]:
-    wwise_plugins_library.append("MasteringSuiteFX")
-    env.Append(CPPDEFINES=["AK_MASTERING_SUITE"])
 
 if env["wwise_config"] == "debug":
     env.Append(CPPDEFINES=["AK_DEBUG"])
@@ -393,10 +430,6 @@ if env["platform"] == "windows":
             env["target_path"] += "release/"
             env.Append(CPPDEFINES=["AK_OPTIMIZED"])
             env.Append(CPPDEFINES=["NDEBUG"])
-
-    if "motion" in env["plugins"]:
-        wwise_plugins_library.append(["AkMotionSink", "AkMotionSourceSource"])
-        env.Append(CPPDEFINES=["AK_MOTION"])
 
     env.Append(
         CPPDEFINES=["WIN32", "_WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS", "UNICODE"]
@@ -592,6 +625,45 @@ elif env["platform"] == "ios":
         ]
     )
 
+# Web build settings
+elif env["platform"] == "web":
+    base_target_path = env["target_path"]
+    env["target_path"] += f"/web/st/"
+    
+    if env["target"] == "template_debug":
+        env["target_path"] += "template_debug/"
+        if env["dev_build"] or env["wwise_config"] == "debug":
+            env["target_path"] += "debug/"
+            env.Append(CPPDEFINES=["_DEBUG"])
+            if env["asserts"]:
+                env.Append(CPPDEFINES=["AK_ENABLE_ASSERTS"])
+        else:
+            env["target_path"] += "profile/"
+            env.Append(CPPDEFINES=["NDEBUG"])
+    else:
+        env["target_path"] += "template_release/"
+        env["target_path"] += "release/"
+        env.Append(CPPDEFINES=["AK_OPTIMIZED"])
+        env.Append(CPPDEFINES=["NDEBUG"])
+
+    env.Append(CXXFLAGS=["-std=c++20"])
+    if env.get("threads", False):
+        env.Append(CCFLAGS=["-pthread", "-matomics", "-msimd128", "-msse4.1", "-fPIC", "-fvisibility=hidden"])
+        env.Append(LINKFLAGS=["-pthread", "-Wl,--allow-multiple-definition"])
+    else:
+        env.Append(CCFLAGS=["-msimd128", "-msse4.1", "-fPIC", "-fvisibility=hidden"])
+        env.Append(LINKFLAGS=["-Wl,--allow-multiple-definition"]) 
+
+    for plugin_name in env.get("plugins", []):
+        if plugin_name in WWISE_WEB_PLUGINS_MAP:
+            plugin_data = WWISE_WEB_PLUGINS_MAP[plugin_name]
+            wwise_plugins_library.extend(plugin_data["libs"])
+        else:
+            print(f"Unknown plugin '{plugin_name}' requested.")
+
+    generated_header_path = "src/gen/wwise_plugins.gen.h"
+    generate_web_plugin_registration(generated_header_path, env)
+
 # godot-cpp settings
 env.Append(
     CPPPATH=[
@@ -661,8 +733,6 @@ if env["platform"] == "macos":
     )
 
 if env["platform"] == "linux":
-    import shutil
-
     library = env.SharedLibrary(
         target=env["target_path"]
         + "libwwise.{}.{}.{}.so".format(env["platform"], env["target"], env["wwise_config"]),
@@ -732,14 +802,40 @@ if env["platform"] == "ios":
     create_output_file_action = Action(target, create_output_file)
     AddPostAction(library, create_output_file)
 
+if env["platform"] == "web":
+    file_name = f"libwwise.{env['platform']}.{env['target']}.{env['wwise_config']}"
+    if not env.get("threads", False):
+        file_name += ".nothreads"
+
+    library = env.SharedLibrary(
+        target=env["target_path"] + file_name + ".wasm",
+        source=sources,
+    )
+
+    worklet_file_name = "WwiseAudioWorklet.processor.js"
+    worklet_src = os.path.join(
+            wwise_emscripten_sample_path,
+            worklet_file_name,
+        )
+    worklet_dir = os.path.join(base_target_path, "web")
+    worklet_dst = os.path.join(worklet_dir, worklet_file_name)
+
+    if not os.path.exists(worklet_src):
+        print(f"Warning: {worklet_src} not found.")
+    else:
+        os.makedirs(worklet_dir, exist_ok=True)
+        shutil.copy2(worklet_src, worklet_dst)
+        print(f"Copied '{worklet_file_name}' to {worklet_dst}")
+
 Default(library)
 
 print_section_header("Wwise Godot Integration: Build Info")
 print_project_info(env)
 
-print_section_header("Copying Plugins")
-dsp_target_path = os.path.join(env["target_path"], "DSP")
-copy_plugins_with_skip(wwise_sdk_plugins_path, dsp_target_path, file_extension, skip_plugins)
+if env["platform"] != "web":
+    print_section_header("Copying Plugins")
+    dsp_target_path = os.path.join(env["target_path"], "DSP")
+    copy_plugins_with_skip(wwise_sdk_plugins_path, dsp_target_path, file_extension, skip_plugins)
 
 if env["platform"] == "ios":
     print_section_header("Copying iOS Plugin Headers")

--- a/addons/Wwise/native/src/core/types/wwise_bank.cpp
+++ b/addons/Wwise/native/src/core/types/wwise_bank.cpp
@@ -3,9 +3,21 @@
 void WwiseBank::_bind_methods()
 {
 	ClassDB::bind_method(D_METHOD("load"), &WwiseBank::load);
+	ClassDB::bind_method(D_METHOD("load_async", "load_callback"), &WwiseBank::load_async);
 	ClassDB::bind_method(D_METHOD("unload"), &WwiseBank::unload);
+	ClassDB::bind_method(D_METHOD("unload_async", "unload_callback"), &WwiseBank::unload_async);
 }
 
 void WwiseBank::load() { AkBankManager::load_bank(get_name()); }
 
+void WwiseBank::load_async(const Callable& p_load_callback)
+{
+	AkBankManager::load_bank_async(get_name(), p_load_callback);
+}
+
 void WwiseBank::unload() { AkBankManager::unload_bank(get_name()); }
+
+void WwiseBank::unload_async(const Callable& p_unload_callback)
+{
+	AkBankManager::unload_bank_async(get_name(), p_unload_callback);
+}

--- a/addons/Wwise/native/src/core/types/wwise_bank.h
+++ b/addons/Wwise/native/src/core/types/wwise_bank.h
@@ -15,5 +15,7 @@ protected:
 public:
 	virtual WwiseObjectType get_object_type() const override { return WwiseObjectType::Soundbank; };
 	void load();
+	void load_async(const Callable& p_load_callback);
 	void unload();
+	void unload_async(const Callable& p_unload_callback);
 };

--- a/addons/Wwise/native/src/core/types/wwise_event.cpp
+++ b/addons/Wwise/native/src/core/types/wwise_event.cpp
@@ -2,6 +2,10 @@
 
 void WwiseEvent::_bind_methods()
 {
+	ClassDB::bind_method(
+			D_METHOD("_on_auto_bank_loaded_async", "bank_id", "result"), &WwiseEvent::_on_auto_bank_loaded_async);
+	ClassDB::bind_method(D_METHOD("_on_prepare_event_completed", "result"), &WwiseEvent::_on_prepare_event_completed);
+
 	ClassDB::bind_method(D_METHOD("set_is_in_user_defined_sound_bank", "is_in_user_defined_soundbank"),
 			&WwiseEvent::set_is_in_user_defined_sound_bank);
 	ClassDB::bind_method(D_METHOD("get_is_in_user_defined_sound_bank"), &WwiseEvent::get_is_in_user_defined_sound_bank);
@@ -58,6 +62,50 @@ void WwiseEvent::_notification(int p_what)
 	}
 }
 
+void WwiseEvent::_process_pending_posts()
+{
+	if (pending_posts.empty())
+		return;
+
+	WwiseLogger::very_verbose_format(
+			"[WwiseEvent] Processing %d deferred posts for %s.", (int)pending_posts.size(), get_name());
+
+	for (const auto& pending : pending_posts)
+	{
+		Node* node = Object::cast_to<Node>(ObjectDB::get_instance(pending.node_id));
+
+		if (node)
+		{
+			if (pending.is_callback)
+			{
+				post_callback(node, pending.flags, pending.cookie);
+			}
+			else
+			{
+				post(node);
+			}
+		}
+	}
+	pending_posts.clear();
+}
+
+void WwiseEvent::_wwise_prepare_event_callback(
+		AkUInt32 in_bankID, const void* in_pInMemoryBankPtr, AKRESULT in_eLoadResult, void* in_Cookie)
+{
+	WwiseEvent* event = static_cast<WwiseEvent*>(in_Cookie);
+	if (event)
+	{
+		Callable(event, StringName("_on_prepare_event_completed")).call_deferred((int)in_eLoadResult);
+	}
+}
+
+void WwiseEvent::load_auto_bank_async()
+{
+	async_state = AsyncState::LOADING_BANK;
+	AkBankManager::load_bank_async(
+			get_name(), Callable(this, StringName("_on_auto_bank_loaded_async")), get_bank_type());
+}
+
 void WwiseEvent::_on_post_resource_init()
 {
 	if (Wwise::get_singleton()->is_initialized())
@@ -73,7 +121,11 @@ void WwiseEvent::load_auto_bank()
 		return;
 	}
 
+#ifdef AK_EMSCRIPTEN
+	load_auto_bank_async();
+#else
 	load_auto_bank_blocking();
+#endif
 }
 
 void WwiseEvent::load_auto_bank_blocking()
@@ -106,11 +158,20 @@ void WwiseEvent::unload_auto_bank()
 	{
 		const AkUniqueID event_id = get_id();
 		AkUniqueID event_ids[] = { event_id };
+
+#ifdef AK_EMSCRIPTEN
+		AK::SoundEngine::PrepareEvent(AK::SoundEngine::Preparation_Unload, event_ids, 1, nullptr, nullptr);
+		AkBankManager::unload_bank_async(get_name(), Callable());
+		set_bank_id(AK_INVALID_UNIQUE_ID);
+		async_state = AsyncState::UNLOADED;
+#else
 		AK::SoundEngine::PrepareEvent(AK::SoundEngine::Preparation_Unload, event_ids, 1);
 		AkBankManager::unload_bank(get_name());
 		set_bank_id(AK_INVALID_UNIQUE_ID);
+#endif
 	}
 }
+
 AkBankTypeEnum WwiseEvent::get_bank_type() const
 {
 	switch (get_object_type())
@@ -124,23 +185,79 @@ AkBankTypeEnum WwiseEvent::get_bank_type() const
 	}
 }
 
-uint32_t WwiseEvent::post(Node* p_node)
+void WwiseEvent::_on_auto_bank_loaded_async(int p_bank_id, int p_result)
 {
-	if (p_node)
+	if (p_result == AK_Success || p_result == AK_BankAlreadyLoaded)
 	{
-		playing_id = Wwise::get_singleton()->post_event_id(get_id(), p_node);
-		if (get_is_in_user_defined_sound_bank() && playing_id == 0)
+		set_bank_id(p_bank_id);
+		async_state = AsyncState::PREPARING_EVENT;
+
+		AkUniqueID event_ids[] = { get_id() };
+
+		AKRESULT res = AK::SoundEngine::PrepareEvent(
+				AK::SoundEngine::Preparation_Load, event_ids, 1, &WwiseEvent::_wwise_prepare_event_callback, this);
+
+		if (res != AK_Success)
 		{
-			WwiseLogger::error(
-					"Post Event failed. This Event is in a User Defined Soundbank. Make sure to add an "
-					"AkBank Node to the Scene Tree and load the corresponding SoundBank before posting the Event.");
+			WwiseLogger::error_format(
+					"Async PrepareEvent for %s failed with result: %s.", get_name(), wwise_error_string(res));
+			async_state = AsyncState::FAILED;
+			pending_posts.clear();
 		}
 	}
 	else
 	{
+		WwiseLogger::error_format("Async Bank Load for event %s failed.", get_name());
+		async_state = AsyncState::FAILED;
+		pending_posts.clear();
+	}
+}
+
+void WwiseEvent::_on_prepare_event_completed(int p_result)
+{
+	if (p_result == AK_Success || p_result == AK_BankAlreadyLoaded)
+	{
+		set_is_auto_bank_loaded(true);
+		async_state = AsyncState::READY;
+		_process_pending_posts();
+	}
+	else
+	{
+		WwiseLogger::error_format("Async PrepareEvent completed with FAILURE for %s", get_name());
+		async_state = AsyncState::FAILED;
+		pending_posts.clear();
+	}
+}
+
+uint32_t WwiseEvent::post(Node* p_node)
+{
+	if (!p_node)
+	{
 		WwiseLogger::warning_format("Could not post Event (name: %s, ID: %d). The Node "
 									"(GameObject) to post the event on has been deleted or is now invalid.",
 				get_name(), get_id());
+		return AK_INVALID_PLAYING_ID;
+	}
+
+#ifdef AK_EMSCRIPTEN
+	if (!get_is_in_user_defined_sound_bank() && async_state != AsyncState::READY && async_state != AsyncState::FAILED)
+	{
+		WwiseLogger::very_verbose_format("[WwiseEvent] Event %s is still loading async. Queuing post().", get_name());
+		PendingPost pending;
+		pending.node_id = p_node->get_instance_id();
+		pending.is_callback = false;
+		pending_posts.push_back(pending);
+
+		return AK_INVALID_PLAYING_ID;
+	}
+#endif
+
+	playing_id = Wwise::get_singleton()->post_event_id(get_id(), p_node);
+	if (get_is_in_user_defined_sound_bank() && playing_id == 0)
+	{
+		WwiseLogger::error(
+				"Post Event failed. This Event is in a User Defined Soundbank. Make sure to add an "
+				"AkBank Node to the Scene Tree and load the corresponding SoundBank before posting the Event.");
 	}
 
 	return playing_id;
@@ -148,21 +265,36 @@ uint32_t WwiseEvent::post(Node* p_node)
 
 uint32_t WwiseEvent::post_callback(Node* p_node, AkUtils::AkCallbackType p_flags, const Callable& cookie)
 {
-	if (p_node)
-	{
-		playing_id = Wwise::get_singleton()->post_event_id_callback(get_id(), p_flags, p_node, cookie);
-		if (get_is_in_user_defined_sound_bank() && playing_id == 0)
-		{
-			WwiseLogger::error(
-					"Post Event failed. This Event is in a User Defined Soundbank. Make sure to add an "
-					"AkBank Node to the Scene Tree and load the corresponding SoundBank before posting the Event.");
-		}
-	}
-	else
+	if (!p_node)
 	{
 		WwiseLogger::warning_format("Could not post Event (name: %s, ID: %d). The Node "
 									"(GameObject) to post the event on has been deleted or is now invalid.",
 				get_name(), get_id());
+		return AK_INVALID_PLAYING_ID;
+	}
+
+#ifdef AK_EMSCRIPTEN
+	if (!get_is_in_user_defined_sound_bank() && async_state != AsyncState::READY && async_state != AsyncState::FAILED)
+	{
+		WwiseLogger::very_verbose_format(
+				"[WwiseEvent] Event %s is still loading async. Queuing post_callback().", get_name());
+		PendingPost pending;
+		pending.node_id = p_node->get_instance_id();
+		pending.is_callback = true;
+		pending.flags = p_flags;
+		pending.cookie = cookie;
+		pending_posts.push_back(pending);
+
+		return AK_INVALID_PLAYING_ID;
+	}
+#endif
+
+	playing_id = Wwise::get_singleton()->post_event_id_callback(get_id(), p_flags, p_node, cookie);
+	if (get_is_in_user_defined_sound_bank() && playing_id == 0)
+	{
+		WwiseLogger::error(
+				"Post Event failed. This Event is in a User Defined Soundbank. Make sure to add an "
+				"AkBank Node to the Scene Tree and load the corresponding SoundBank before posting the Event.");
 	}
 
 	return playing_id;

--- a/addons/Wwise/native/src/core/types/wwise_event.h
+++ b/addons/Wwise/native/src/core/types/wwise_event.h
@@ -26,6 +26,32 @@ private:
 	bool is_auto_bank_loaded{};
 	uint32_t playing_id{ AK_INVALID_PLAYING_ID };
 
+private:
+	enum class AsyncState
+	{
+		UNLOADED,
+		LOADING_BANK,
+		PREPARING_EVENT,
+		READY,
+		FAILED
+	};
+
+	struct PendingPost
+	{
+		ObjectID node_id;
+		bool is_callback{ false };
+		AkUtils::AkCallbackType flags;
+		Callable cookie;
+	};
+
+	AsyncState async_state{ AsyncState::UNLOADED };
+	std::vector<PendingPost> pending_posts;
+
+	void _process_pending_posts();
+	static void _wwise_prepare_event_callback(
+			AkUInt32 in_bankID, const void* in_pInMemoryBankPtr, AKRESULT in_eLoadResult, void* in_Cookie);
+	void load_auto_bank_async();
+
 	void _on_post_resource_init();
 	void load_auto_bank();
 	void load_auto_bank_blocking();
@@ -34,6 +60,9 @@ private:
 	AkBankTypeEnum get_bank_type() const;
 
 public:
+	void _on_auto_bank_loaded_async(int p_bank_id, int p_result);
+	void _on_prepare_event_completed(int p_result);
+
 	virtual WwiseObjectType get_object_type() const override { return WwiseObjectType::Event; };
 
 	uint32_t post(Node* p_node);

--- a/addons/Wwise/native/src/core/wwise_bank_manager.h
+++ b/addons/Wwise/native/src/core/wwise_bank_manager.h
@@ -1,108 +1,149 @@
 #pragma once
 
-#include "core/wwise_logger.h"
+#include "core/utils.h"
 #include <AK/SoundEngine/Common/AkSoundEngine.h>
 #include <AK/SoundEngine/Common/AkTypes.h>
 #include <AK/Tools/Common/AkAutoLock.h>
 #include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/callable.hpp>
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 using namespace godot;
 
 class AkBankManager
 {
 public:
-	struct BankHandle
+	enum class BankState
+	{
+		UNLOADED,
+		LOADING,
+		LOADED,
+		FAILED,
+		UNLOADING,
+		READY_TO_DELETE
+	};
+
+private:
+	struct BankEntry
 	{
 		String bank_name;
-		uint32_t bank_id{};
-		AkBankTypeEnum bank_type;
-		int ref_count = {};
+		AkBankID bank_id{ AK_INVALID_BANK_ID };
+		AkBankTypeEnum bank_type{ AkBankTypeEnum::AkBankType_User };
 
-		BankHandle(const String& p_name, AkBankTypeEnum p_type) : bank_name(p_name), bank_type(p_type) {}
+		int ref_count{ 0 };
+		BankState state{ BankState::UNLOADED };
 
-		void inc_ref()
+		std::vector<Callable> load_callbacks;
+		Callable unload_callback;
+
+		bool wants_async_unload{ false };
+
+		BankEntry(const String& p_name, AkBankID p_id, AkBankTypeEnum p_type) :
+				bank_name(p_name), bank_id(p_id), bank_type(p_type)
 		{
-			if (ref_count == 0)
-			{
-				banks_to_unload.erase(this);
-			}
-			ref_count++;
-		}
-
-		void dec_ref()
-		{
-			ref_count--;
-			if (ref_count == 0)
-			{
-				banks_to_unload.push_back(this);
-			}
-		}
-
-		uint32_t load_bank()
-		{
-			if (ref_count == 0 && !banks_to_unload.erase(this))
-			{
-				auto result = AK::SoundEngine::LoadBank(bank_name.utf8().get_data(), bank_id, bank_type);
-				log_load_result(result);
-			}
-
-			inc_ref();
-			return bank_id;
-		}
-
-		void unload_bank(bool remove = true)
-		{
-			AK::SoundEngine::UnloadBank(bank_id, nullptr, bank_type);
-
-			if (remove)
-			{
-				AkAutoLock<CAkLock> scoped_lock(bank_handles_lock);
-				auto find = bank_handles.find(bank_name);
-				if (find != bank_handles.end())
-				{
-					bank_handles.remove(find);
-				}
-			}
-		}
-
-		void log_load_result(AKRESULT result)
-		{
-			if (result != AK_Success)
-			{
-				WwiseLogger::error_format("Bank %s failed to load (%s).", bank_name, wwise_error_string(result));
-			}
 		}
 	};
 
-	static HashMap<String, BankHandle*> bank_handles;
-	static Vector<BankHandle*> banks_to_unload;
-	static CAkLock bank_handles_lock;
-
-	static void do_unload_banks()
+	enum class CommandType
 	{
-		for (auto* bank : banks_to_unload)
+		LOAD_FINISHED,
+		UNLOAD_FINISHED
+	};
+
+	struct AsyncCommand
+	{
+		CommandType type;
+		BankEntry* entry_ptr;
+		AKRESULT result;
+	};
+
+	static inline std::unordered_map<AkBankID, BankEntry*> active_banks;
+	static inline std::vector<BankEntry*> unload_queue;
+
+	static inline std::vector<AsyncCommand> result_queue;
+	static inline CAkLock result_queue_mutex;
+
+	static String bake_state_to_string(BankState state)
+	{
+		switch (state)
 		{
-			bank->unload_bank();
-			delete bank;
+			case BankState::UNLOADED:
+				return "BankState::UNLOADED";
+			case BankState::LOADING:
+				return "BankState::LOADING";
+			case BankState::LOADED:
+				return "BankState::LOADED";
+			case BankState::FAILED:
+				return "BankState::FAILED";
+			case BankState::UNLOADING:
+				return "BankState::UNLOADING";
+			case BankState::READY_TO_DELETE:
+				return "BankState::READY_TO_DELETE";
+			default:
+				return "UNKNOWN_STATE";
 		}
-		banks_to_unload.clear();
 	}
 
-	static void reset()
+	static void _wwise_load_callback(
+			AkUInt32 in_bankID, const void* in_pInMemoryBankPtr, AKRESULT in_eLoadResult, void* in_Cookie)
 	{
-		AkAutoLock<CAkLock> scoped_lock(bank_handles_lock);
-		for (auto& entry : bank_handles)
-		{
-			delete entry.value;
-		}
-		for (auto* bank : banks_to_unload)
-		{
-			delete bank;
-		}
-		bank_handles.clear();
-		banks_to_unload.clear();
+		WwiseLogger::very_verbose_format("[AkBankManager] Load callback fired: bank %s result %s", in_bankID,
+				wwise_error_string(in_eLoadResult));
+		BankEntry* entry = static_cast<BankEntry*>(in_Cookie);
+		AkAutoLock lock(result_queue_mutex);
+		result_queue.push_back({ CommandType::LOAD_FINISHED, entry, in_eLoadResult });
 	}
+
+	static void _wwise_unload_callback(
+			AkUInt32 in_bankID, const void* in_pInMemoryBankPtr, AKRESULT in_eUnloadResult, void* in_Cookie)
+	{
+		WwiseLogger::very_verbose_format("[AkBankManager] Unload callback fired: bank %s result %s", in_bankID,
+				wwise_error_string(in_eUnloadResult));
+		BankEntry* entry = static_cast<BankEntry*>(in_Cookie);
+		AkAutoLock lock(result_queue_mutex);
+		result_queue.push_back({ CommandType::UNLOAD_FINISHED, entry, in_eUnloadResult });
+	}
+
+	static BankEntry* _get_or_create_entry(const String& p_name, AkBankID p_id, AkBankTypeEnum p_type, bool& out_is_new)
+	{
+		auto it = active_banks.find(p_id);
+
+		if (it != active_banks.end())
+		{
+			BankEntry* entry = it->second;
+
+			if (entry->state == BankState::UNLOADING || entry->state == BankState::READY_TO_DELETE)
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Bank %s is unloading. Spawning new entry.", p_name);
+				active_banks.erase(it);
+			}
+			else
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Found existing entry for bank %s", p_name);
+				out_is_new = false;
+				return entry;
+			}
+		}
+
+		WwiseLogger::very_verbose_format("[AkBankManager] Creating new entry for bank %s", p_name);
+		BankEntry* new_entry = new BankEntry(p_name, p_id, p_type);
+		active_banks[p_id] = new_entry;
+		out_is_new = true;
+		return new_entry;
+	}
+
+	static void _queue_for_unload(BankEntry* entry)
+	{
+		WwiseLogger::very_verbose_format("[AkBankManager] Queuing bank %s for unload", entry->bank_name);
+		unload_queue.push_back(entry);
+	}
+
+public:
+	static void init() { reset(); }
 
 	static void load_init_bank(bool do_reset = true)
 	{
@@ -111,61 +152,331 @@ public:
 			reset();
 		}
 
+		WwiseLogger::very_verbose("[AkBankManager] Loading Init.bnk...");
 		AkBankID bank_id;
 		AKRESULT result = AK::SoundEngine::LoadBank("Init.bnk", bank_id);
 		if (result != AK_Success)
 		{
-			WwiseLogger::error_format("Failed to load Init.bnk with result: %s", wwise_error_string(result));
+			WwiseLogger::warning_format("Failed to load Init.bnk with result: %s", wwise_error_string(result));
+		}
+		else
+		{
+			WwiseLogger::very_verbose("[AkBankManager] Init.bnk loaded successfully.");
 		}
 	}
 
-	static void load_init_bank_id(bool do_reset = true)
+	static uint32_t load_bank(const String& p_name, AkBankTypeEnum p_type = AkBankType_User)
 	{
-		if (do_reset)
-		{
-			reset();
-		}
+		WwiseLogger::very_verbose_format("[AkBankManager] load_bank called for %s", p_name);
+		AkBankID bank_id = AK::SoundEngine::GetIDFromString(p_name.utf8().get_data());
+		bool is_new = false;
+		BankEntry* entry = _get_or_create_entry(p_name, bank_id, p_type, is_new);
 
-		AkUInt32 init_bank_id = AK::SoundEngine::GetIDFromString("Init");
-		AKRESULT result = AK::SoundEngine::LoadBank(init_bank_id);
-		if (result != AK_Success)
-		{
-			WwiseLogger::error_format("Failed to load Init.bnk with result: %s", wwise_error_string(result));
-		}
-	}
+		entry->ref_count++;
+		WwiseLogger::very_verbose_format("[AkBankManager] Ref count for %s is now %d", p_name, entry->ref_count);
 
-	static void unload_init_bank() { AK::SoundEngine::UnloadBank("Init.bnk", nullptr); }
-
-	static uint32_t load_bank(const String& name, AkBankTypeEnum bankType = AkBankTypeEnum::AkBankType_User)
-	{
-		BankHandle* handle{ nullptr };
+		if (is_new)
 		{
-			AkAutoLock<CAkLock> scoped_lock(bank_handles_lock);
-			if (bank_handles.has(name))
+			WwiseLogger::very_verbose_format("[AkBankManager] Synchronous load starting for %s", p_name);
+			entry->state = BankState::LOADING;
+			AKRESULT res = AK::SoundEngine::LoadBank(p_name.utf8().get_data(), entry->bank_id, p_type);
+
+			if (res == AK_Success || res == AK_BankAlreadyLoaded)
 			{
-				handle = bank_handles[name];
-				handle->inc_ref();
-				return AK_INVALID_UNIQUE_ID;
+				WwiseLogger::very_verbose_format("[AkBankManager] Sync load succeeded for %s", p_name);
+				entry->state = BankState::LOADED;
+			}
+			else
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Sync load FAILED for %s", p_name);
+				entry->state = BankState::FAILED;
+				active_banks.erase(bank_id);
+				delete entry;
+				return AK_INVALID_BANK_ID;
+			}
+		}
+		else
+		{
+			if (entry->state == BankState::LOADING)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Cannot synchronously load bank %s while it is asynchronously loading.",
+						p_name);
+				entry->ref_count--;
+				return AK_INVALID_BANK_ID;
+			}
+		}
+
+		return entry->bank_id;
+	}
+
+	static uint32_t load_bank_async(
+			const String& p_name, const Callable& p_callback, AkBankTypeEnum p_type = AkBankType_User)
+	{
+		WwiseLogger::very_verbose_format("[AkBankManager] load_bank_async called for %s", p_name);
+		AkBankID bank_id = AK::SoundEngine::GetIDFromString(p_name.utf8().get_data());
+		bool is_new = false;
+		BankEntry* entry = _get_or_create_entry(p_name, bank_id, p_type, is_new);
+
+		entry->ref_count++;
+		WwiseLogger::very_verbose_format("[AkBankManager] Ref count for %s is now %d", p_name, entry->ref_count);
+
+		if (p_callback.is_valid())
+		{
+			if (entry->state == BankState::LOADED)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Bank %s already LOADED. Firing callback immediately.", p_name);
+				p_callback.call_deferred(entry->bank_id, AK_BankAlreadyLoaded);
+			}
+			else if (entry->state == BankState::FAILED)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Bank %s previously FAILED. Firing callback immediately.", p_name);
+				p_callback.call_deferred(entry->bank_id, AK_Fail);
+			}
+			else
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Registering async load callback for %s", p_name);
+				entry->load_callbacks.push_back(p_callback);
+			}
+		}
+		else
+		{
+			WwiseLogger::very_verbose_format("[AkBankManager] No valid callback provided for async load of %s", p_name);
+		}
+
+		if (is_new)
+		{
+			WwiseLogger::very_verbose_format("[AkBankManager] Scheduling async load for %s", p_name);
+			entry->state = BankState::LOADING;
+			AKRESULT res = AK::SoundEngine::LoadBank(
+					p_name.utf8().get_data(), &_wwise_load_callback, entry, entry->bank_id, p_type);
+
+			if (res != AK_Success)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Async load scheduling FAILED for %s (result=%d)", p_name, res);
+				entry->state = BankState::FAILED;
+
+				for (const Callable& cb : entry->load_callbacks)
+				{
+					if (cb.is_valid())
+						cb.call_deferred(entry->bank_id, (int)res);
+				}
+				entry->load_callbacks.clear();
+			}
+		}
+
+		return entry->bank_id;
+	}
+
+	static void unload_bank(const String& p_name)
+	{
+		WwiseLogger::very_verbose_format("[AkBankManager] unload_bank called for %s", p_name);
+		AkBankID bank_id = AK::SoundEngine::GetIDFromString(p_name.utf8().get_data());
+
+		auto it = active_banks.find(bank_id);
+
+		if (it != active_banks.end())
+		{
+			BankEntry* entry = it->second;
+			entry->wants_async_unload = false;
+
+			int prev = entry->ref_count--;
+			WwiseLogger::very_verbose_format("[AkBankManager] Ref count for %s is now %d", p_name, prev - 1);
+
+			if (prev == 1)
+			{
+				_queue_for_unload(entry);
+			}
+		}
+		else
+		{
+			WwiseLogger::very_verbose_format(
+					"[AkBankManager] Ignored unload_bank for %s: Not found in active_banks.", p_name);
+		}
+	}
+
+	static void unload_bank_async(const String& p_name, const Callable& p_callback)
+	{
+		WwiseLogger::very_verbose_format("[AkBankManager] unload_bank_async called for %s", p_name);
+		AkBankID bank_id = AK::SoundEngine::GetIDFromString(p_name.utf8().get_data());
+
+		auto it = active_banks.find(bank_id);
+
+		if (it != active_banks.end())
+		{
+			BankEntry* entry = it->second;
+			entry->wants_async_unload = true;
+
+			if (p_callback.is_valid())
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Storing async unload callback for %s", p_name);
+				entry->unload_callback = p_callback;
 			}
 
-			handle = new BankHandle(name, bankType);
-			bank_handles.insert(name, handle);
-		}
+			int prev = entry->ref_count--;
+			WwiseLogger::very_verbose_format("[AkBankManager] Ref count for %s is now %d", p_name, prev - 1);
 
-		return handle->load_bank();
+			if (prev == 1)
+			{
+				_queue_for_unload(entry);
+			}
+		}
+		else
+		{
+			WwiseLogger::very_verbose_format(
+					"[AkBankManager] Ignored async unload for %s: Not found in active_banks. Firing success callback.",
+					p_name);
+
+			if (p_callback.is_valid())
+				p_callback.call_deferred(bank_id, AK_Success);
+		}
 	}
 
-	static void unload_bank(const String& name)
+	static void update()
 	{
-		AkAutoLock<CAkLock> scoped_lock(bank_handles_lock);
+		_process_async_results();
+		_process_unload_queue();
+	}
 
-		if (bank_handles.has(name))
+	static void reset()
+	{
+		WwiseLogger::very_verbose_format(
+				"[AkBankManager] RESET called - moving %d active banks to unload queue", (int)active_banks.size());
+
+		for (auto& pair : active_banks)
 		{
-			bank_handles[name]->dec_ref();
+			BankEntry* entry = pair.second;
+			entry->ref_count = 0;
+			unload_queue.push_back(entry);
+		}
+		active_banks.clear();
+	}
+
+private:
+	static void _process_async_results()
+	{
+		std::vector<AsyncCommand> commands;
+		{
+			AkAutoLock lock(result_queue_mutex);
+			if (result_queue.empty())
+				return;
+			commands.swap(result_queue);
+		}
+
+		WwiseLogger::very_verbose_format("[AkBankManager] Processing %d async results", (int)commands.size());
+
+		for (const auto& cmd : commands)
+		{
+			BankEntry* entry = cmd.entry_ptr;
+
+			if (cmd.type == CommandType::LOAD_FINISHED)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Async LOAD COMPLETE for %s result=%d", entry->bank_name, cmd.result);
+
+				if (cmd.result == AK_Success || cmd.result == AK_BankAlreadyLoaded)
+					entry->state = BankState::LOADED;
+				else
+					entry->state = BankState::FAILED;
+
+				for (const Callable& cb : entry->load_callbacks)
+				{
+					if (cb.is_valid())
+						cb.call(entry->bank_id, (int)cmd.result);
+				}
+				entry->load_callbacks.clear();
+			}
+			else if (cmd.type == CommandType::UNLOAD_FINISHED)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Async UNLOAD COMPLETE for %s result=%d", entry->bank_name, cmd.result);
+
+				if (entry->unload_callback.is_valid())
+					entry->unload_callback.call(entry->bank_id, (int)cmd.result);
+
+				entry->state = BankState::READY_TO_DELETE;
+			}
+		}
+	}
+
+	static void _process_unload_queue()
+	{
+		for (int i = unload_queue.size() - 1; i >= 0; i--)
+		{
+			BankEntry* entry = unload_queue[i];
+
+			if (entry->ref_count > 0 && entry->state != BankState::UNLOADING &&
+					entry->state != BankState::READY_TO_DELETE)
+			{
+				WwiseLogger::very_verbose_format(
+						"[AkBankManager] Bank %s resurrected from unload queue!", entry->bank_name);
+				unload_queue[i] = unload_queue.back();
+				unload_queue.pop_back();
+				continue;
+			}
+
+			WwiseLogger::very_verbose_format("[AkBankManager] Checking unload queue entry: %s (state=%s)",
+					entry->bank_name, bake_state_to_string(entry->state));
+
+			if (entry->state == BankState::LOADING)
+				continue;
+			if (entry->state == BankState::UNLOADING)
+				continue;
+
+			if (entry->state == BankState::READY_TO_DELETE)
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Deleting bank entry %s", entry->bank_name);
+
+				auto it = active_banks.find(entry->bank_id);
+				if (it != active_banks.end() && it->second == entry)
+				{
+					active_banks.erase(it);
+				}
+
+				delete entry;
+				unload_queue[i] = unload_queue.back();
+				unload_queue.pop_back();
+				continue;
+			}
+
+			bool is_async = entry->wants_async_unload;
+
+			if (is_async)
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Starting async unload for %s", entry->bank_name);
+				entry->state = BankState::UNLOADING;
+
+				AKRESULT res = AK::SoundEngine::UnloadBank(
+						entry->bank_name.utf8().get_data(), nullptr, &_wwise_unload_callback, entry, entry->bank_type);
+
+				if (res != AK_Success)
+				{
+					WwiseLogger::warning_format("[AkBankManager] Async unload rejected immediately for %s (result=%d). "
+												"Manual cleanup triggered.",
+							entry->bank_name, res);
+
+					AkAutoLock lock(result_queue_mutex);
+					result_queue.push_back({ CommandType::UNLOAD_FINISHED, entry, res });
+				}
+			}
+			else
+			{
+				WwiseLogger::very_verbose_format("[AkBankManager] Starting sync unload for %s", entry->bank_name);
+				AK::SoundEngine::UnloadBank(entry->bank_name.utf8().get_data(), nullptr, entry->bank_type);
+
+				auto it = active_banks.find(entry->bank_id);
+				if (it != active_banks.end() && it->second == entry)
+				{
+					active_banks.erase(it);
+				}
+
+				delete entry;
+				unload_queue[i] = unload_queue.back();
+				unload_queue.pop_back();
+			}
 		}
 	}
 };
-
-CAkLock AkBankManager::bank_handles_lock;
-HashMap<String, AkBankManager::BankHandle*> AkBankManager::bank_handles;
-Vector<AkBankManager::BankHandle*> AkBankManager::banks_to_unload;

--- a/addons/Wwise/native/src/core/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/core/wwise_gdextension.cpp
@@ -6,6 +6,10 @@
 
 #include <AK/Plugin/AllPluginsFactories.h>
 
+#if defined(AK_EMSCRIPTEN)
+#include "gen/wwise_plugins.gen.h"
+#endif
+
 #include "scene/ak_game_obj.h"
 #include "scene/ak_game_obj_2d.h"
 #include "scene/ak_game_obj_3d.h"
@@ -226,6 +230,8 @@ void Wwise::init()
 	banks_platform_suffix = load_platform_suffix(project_settings->project_settings.ios_platform_info);
 #elif defined(AK_ANDROID)
 	banks_platform_suffix = load_platform_suffix(project_settings->project_settings.android_platform_info);
+#elif defined(AK_EMSCRIPTEN)
+	banks_platform_suffix = load_platform_suffix(project_settings->project_settings.web_platform_info);
 #else
 #error "Platform not supported"
 #endif
@@ -258,21 +264,16 @@ void Wwise::init()
 
 	low_level_io.set_use_subfolders(use_subfolders);
 
-	bool use_soundbank_names = project_settings->get_setting(project_settings->project_settings.use_soundbank_names);
-
-	if (use_soundbank_names)
-	{
-		AkBankManager::load_init_bank();
-	}
-	else
-	{
-		AkBankManager::load_init_bank_id();
-	}
+	AkBankManager::load_init_bank();
 }
 
 void Wwise::render_audio()
 {
-	AkBankManager::do_unload_banks();
+	AkBankManager::update();
+#if !defined(AK_SUPPORT_THREADS)
+	AK::StreamMgr::PerformIO();
+	AK::SoundEngine::ProcessBanks();
+#endif
 	ERROR_CHECK(AK::SoundEngine::RenderAudio());
 }
 
@@ -397,8 +398,7 @@ bool Wwise::register_game_obj(const Node* game_object, const String& game_object
 	AkGameObjectID id = get_ak_game_object_id(game_object);
 	AKRESULT result = AK::SoundEngine::RegisterGameObj(id, game_object_name.utf8().get_data());
 	post_register_game_object(result, game_object, id);
-	return ERROR_CHECK_MSG(
-			result, vformat("Failed to register Game Object with name: %s.", game_object_name));
+	return ERROR_CHECK_MSG(result, vformat("Failed to register Game Object with name: %s.", game_object_name));
 }
 
 bool Wwise::unregister_game_obj(const Node* game_object)
@@ -1067,8 +1067,7 @@ bool Wwise::set_geometry(const Array vertices, const Array triangles, const Ref<
 
 	if (triangles.size() % 3 != 0)
 	{
-		WwiseLogger::verbose_format(
-				"Wrong number of triangles on GameObject: %s.", game_object->get_path());
+		WwiseLogger::verbose_format("Wrong number of triangles on GameObject: %s.", game_object->get_path());
 	}
 
 	int num_triangles = triangles.size() / 3;
@@ -1823,16 +1822,17 @@ bool Wwise::initialize_wwise_systems()
 	platform_init_settings.eAudioPath = AkAudioPath_LowLatency;
 
 #elif defined(AK_LINUX)
-
 	platform_init_settings.eAudioAPI = static_cast<AkAudioAPILinux>(static_cast<unsigned int>(
 			project_settings->get_setting(project_settings->platform_settings.linux_audio_api)));
-
+#elif defined(AK_EMSCRIPTEN)
+	platform_init_settings.bVerboseSystemOutput =
+			project_settings->get_setting(project_settings->platform_settings.web_verbose_system_output);
 #else
 #error "Platform not supported"
 #endif
 
-	if (!ERROR_CHECK_MSG(AK::SoundEngine::Init(&init_settings, &platform_init_settings),
-				"Sound engine initialization failed."))
+	if (!ERROR_CHECK_MSG(
+				AK::SoundEngine::Init(&init_settings, &platform_init_settings), "Sound engine initialization failed."))
 
 	{
 		return false;
@@ -1912,6 +1912,12 @@ bool Wwise::initialize_wwise_systems()
 	String network_name = project_settings->get_setting(project_settings->communication_settings.network_name);
 	AKPLATFORM::SafeStrCpy(
 			comm_settings.szAppNetworkName, network_name.utf8().get_data(), AK_COMM_SETTINGS_MAX_STRING_SIZE);
+
+#if defined(AK_EMSCRIPTEN)
+	String proxy_server_url = project_settings->get_setting(project_settings->communication_settings.proxy_server_url);
+	AKPLATFORM::SafeStrCpy(
+			comm_settings.szCommProxyServerUrl, proxy_server_url.utf8().get_data(), AK_COMM_SETTINGS_MAX_URL_SIZE);
+#endif
 
 	ERROR_CHECK_MSG(AK::Comm::Init(comm_settings), "Comm initialization failed.");
 #endif

--- a/addons/Wwise/native/src/core/wwise_settings.cpp
+++ b/addons/Wwise/native/src/core/wwise_settings.cpp
@@ -79,6 +79,7 @@ WwiseSettings::WwiseSettings()
 	communication_settings.initialize_system_comms = "wwise/communication_settings/initialize_system_comms";
 	communication_settings.network_name = "wwise/communication_settings/network_name";
 	communication_settings.waapi_port = "wwise/communication_settings/waapi_port";
+	communication_settings.proxy_server_url = "wwise/communication_settings/proxy_server_url";
 
 	// Platform Settings
 	platform_settings.windows_max_system_audio_objects = "wwise/windows_advanced_settings/max_system_audio_objects";
@@ -89,9 +90,9 @@ WwiseSettings::WwiseSettings()
 	platform_settings.ios_audio_session_mode = "wwise/ios_advanced_settings/audio_session_mode";
 	platform_settings.android_audio_api = "wwise/android_advanced_settings/audio_API";
 	platform_settings.linux_audio_api = "wwise/linux_advanced_settings/audio_API";
+	platform_settings.web_verbose_system_output = "wwise/web_advanced_settings/verbose_system_output";
 
 	// Project Settings
-	project_settings.use_soundbank_names = "wwise/project_settings/use_soundbank_names";
 	project_settings.create_subfolders_for_generated_files =
 			"wwise/project_settings/create_subfolders_for_generated_files";
 	project_settings.windows_platform_info = "wwise/project_settings/windows_platform_info";
@@ -99,6 +100,7 @@ WwiseSettings::WwiseSettings()
 	project_settings.linux_platform_info = "wwise/project_settings/linux_platform_info";
 	project_settings.ios_platform_info = "wwise/project_settings/ios_platform_info";
 	project_settings.android_platform_info = "wwise/project_settings/android_platform_info";
+	project_settings.web_platform_info = "wwise/project_settings/web_platform_info";
 	project_settings.custom_platform_name = "wwise/project_settings/custom_platform_name";
 
 	// Wwise Logger Settings
@@ -158,6 +160,8 @@ Variant WwiseSettings::get_setting(const StringName& p_setting, const Variant& p
 	platform_setting += GODOT_ANDROID_SETTING_POSTFIX;
 #elif defined(AK_LINUX)
 	platform_setting += GODOT_LINUX_SETTING_POSTFIX;
+#elif defined(AK_EMSCRIPTEN)
+	platform_setting += GODOT_WEB_SETTING_POSTFIX;
 #else
 #error "Platform not supported"
 #endif
@@ -250,6 +254,7 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(communication_settings.initialize_system_comms, true, Variant::Type::BOOL);
 	add_setting(communication_settings.network_name, "", Variant::Type::STRING);
 	add_setting(communication_settings.waapi_port, 8080, Variant::Type::INT);
+	add_setting(communication_settings.proxy_server_url, "ws://localhost:8095/", Variant::Type::STRING);
 
 	// Platform Settings
 	add_setting(platform_settings.windows_max_system_audio_objects, 128, Variant::Type::INT);
@@ -265,9 +270,9 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(platform_settings.android_audio_api, 4, Variant::Type::INT, PROPERTY_HINT_ENUM,
 			"AAudio,OPENSL_ES,DolbyAtmos,AndroidSpatializer,Default");
 	add_setting(platform_settings.linux_audio_api, 3, Variant::Type::INT, PROPERTY_HINT_FLAGS, "PulseAudio, ALSA");
+	add_setting(platform_settings.web_verbose_system_output, false, Variant::Type::BOOL);
 
 	// Project Settings
-	add_setting(project_settings.use_soundbank_names, true, Variant::Type::BOOL, PROPERTY_HINT_NONE, "");
 	add_setting(
 			project_settings.create_subfolders_for_generated_files, false, Variant::Type::BOOL, PROPERTY_HINT_NONE, "");
 	add_setting(project_settings.windows_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
@@ -275,6 +280,7 @@ void WwiseSettings::add_wwise_settings()
 	add_setting(project_settings.linux_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
 	add_setting(project_settings.ios_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
 	add_setting(project_settings.android_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
+	add_setting(project_settings.web_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
 	add_setting(project_settings.custom_platform_name, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
 
 	// Wwise Logger Settings

--- a/addons/Wwise/native/src/core/wwise_settings.h
+++ b/addons/Wwise/native/src/core/wwise_settings.h
@@ -96,6 +96,7 @@ public:
 		StringName initialize_system_comms;
 		StringName network_name;
 		StringName waapi_port;
+		StringName proxy_server_url;
 	};
 
 	struct PlatformSettings
@@ -108,17 +109,18 @@ public:
 		StringName ios_audio_session_mode;
 		StringName android_audio_api;
 		StringName linux_audio_api;
+		StringName web_verbose_system_output;
 	};
 
 	struct ProjectSettings
 	{
-		StringName use_soundbank_names;
 		StringName create_subfolders_for_generated_files;
 		StringName windows_platform_info;
 		StringName mac_platform_info;
 		StringName linux_platform_info;
 		StringName ios_platform_info;
 		StringName android_platform_info;
+		StringName web_platform_info;
 		StringName custom_platform_name;
 	};
 
@@ -140,6 +142,7 @@ public:
 	String GODOT_LINUX_SETTING_POSTFIX = ".linux";
 	String GODOT_IOS_SETTING_POSTFIX = ".ios";
 	String GODOT_ANDROID_SETTING_POSTFIX = ".android";
+	String GODOT_WEB_SETTING_POSTFIX = ".web";
 
 	static WwiseSettings* get_singleton();
 	WwiseSettings();

--- a/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.cpp
+++ b/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.cpp
@@ -193,6 +193,29 @@ void AkEditorExportPlugin::add_files_recursive(Ref<DirAccess> dir, const String&
 	dir->list_dir_end();
 }
 
+void AkEditorExportPlugin::export_web_audio_worklet(const String& p_path)
+{
+	const String worklet_source = "res://addons/Wwise/native/lib/web/WwiseAudioWorklet.processor.js";
+
+	if (!FileAccess::file_exists(worklet_source))
+	{
+		WwiseLogger::warning("WwiseAudioWorklet.processor.js is missing from res://addons/Wwise/native/lib/web/.");
+		return;
+	}
+
+	const String export_directory = p_path.get_base_dir();
+	const String destination_path = export_directory.path_join("WwiseAudioWorklet.processor.js");
+
+	godot::Error copy_result = DirAccess::copy_absolute(worklet_source, destination_path);
+
+	if (copy_result != OK)
+	{
+		WwiseLogger::error_format("Failed to export web audio worklet. Source: %s, Destination: %s, Error: %d",
+				worklet_source, destination_path, copy_result);
+		return;
+	}
+}
+
 String AkEditorExportPlugin::_get_name() const { return "AkEditorExportPlugin"; }
 
 void AkEditorExportPlugin::_export_begin(
@@ -209,7 +232,8 @@ void AkEditorExportPlugin::_export_begin(
 		{ "macos", settings->project_settings.mac_platform_info },
 		{ "linux", settings->project_settings.linux_platform_info },
 		{ "ios", settings->project_settings.ios_platform_info },
-		{ "android", settings->project_settings.android_platform_info } };
+		{ "android", settings->project_settings.android_platform_info },
+		{ "web", settings->project_settings.web_platform_info } };
 
 	for (const auto& feature : p_features)
 	{
@@ -234,6 +258,11 @@ void AkEditorExportPlugin::_export_begin(
 		}
 
 		add_files_recursive(dir, platform_banks_path);
+
+		if (feature == "web")
+		{
+			export_web_audio_worklet(p_path);
+		}
 
 		String library_path = get_platform_library_path(gdextension_config, it->first, p_features, p_is_debug);
 		String dsp_path = library_path.get_base_dir().path_join("DSP");

--- a/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.h
+++ b/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "core/wwise_logger.h"
 #include "core/wwise_platform_info.h"
-#include "core/wwise_settings.h"
 #include "editor/ak_editor_settings.h"
 #include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/dir_access.hpp>
@@ -33,6 +33,7 @@ private:
 	void handle_android_plugin(
 			const Ref<WwisePluginInfo>& p_plugin_info, const String& p_dsp_path, const PackedStringArray& p_features);
 	void add_files_recursive(Ref<DirAccess> dir, const String& base_path);
+	void export_web_audio_worklet(const String& p_path);
 
 public:
 	virtual String _get_name() const override;

--- a/addons/Wwise/native/src/editor/wwise_project_database.cpp
+++ b/addons/Wwise/native/src/editor/wwise_project_database.cpp
@@ -40,7 +40,11 @@ void WwiseProjectDatabase::post_init_callback()
 				settings->project_settings.create_subfolders_for_generated_files, subfolders_for_generated_files);
 
 		bool use_soundbank_names = platform_data->PlatformRef.GetPlatformInfo()->Settings.bUseSoundBankNames;
-		settings->set_setting(settings->project_settings.use_soundbank_names, use_soundbank_names);
+		if (!use_soundbank_names)
+		{
+			WwiseLogger::error("The 'Use SoundBank Names for Filenames' setting in the Wwise Authoring SoundBanks "
+								 "settings must be enabled. After enabling the setting, regenerate the SoundBanks.");
+		}
 
 		std::map<WwiseDBString, StringName> platform_data_map = {
 			{ "Windows", settings->project_settings.windows_platform_info },
@@ -48,6 +52,7 @@ void WwiseProjectDatabase::post_init_callback()
 			{ "Linux", settings->project_settings.linux_platform_info },
 			{ "iOS", settings->project_settings.ios_platform_info },
 			{ "Android", settings->project_settings.android_platform_info },
+			{ "Web", settings->project_settings.web_platform_info }
 		};
 
 		const auto& project_info = platform_data->PlatformRef.ProjectInfo.GetProjectInfo();
@@ -90,10 +95,10 @@ void WwiseProjectDatabase::post_init_callback()
 					String plugin_name = plugin->name;
 					String plugin_dll = plugin->dll;
 					String plugin_static_lib = plugin->staticLib;
-					
+
 					Ref<WwisePluginInfo> plugin_info;
 					plugin_info.instantiate();
-					plugin_info->set_plugin_name(plugin_name); 
+					plugin_info->set_plugin_name(plugin_name);
 					plugin_info->set_plugin_id(plugin_id);
 					plugin_info->set_dll_name(plugin_dll);
 					plugin_info->set_static_lib_name(plugin_static_lib);

--- a/addons/Wwise/native/src/platform/emscripten/ak_emscripten_atomics.cpp
+++ b/addons/Wwise/native/src/platform/emscripten/ak_emscripten_atomics.cpp
@@ -1,0 +1,73 @@
+#if defined(AK_EMSCRIPTEN)
+#include <emscripten/emscripten.h>
+extern "C"
+{
+	GDE_EXPORT uint32_t emscripten_atomic_load_u32(const void* addr)
+	{
+		return __atomic_load_n((const volatile uint32_t*)addr, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint64_t emscripten_atomic_load_u64(const void* addr)
+	{
+		return __atomic_load_n((const volatile uint64_t*)addr, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint32_t emscripten_atomic_exchange_u32(void* addr, uint32_t value)
+	{
+		return __atomic_exchange_n((volatile uint32_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint64_t emscripten_atomic_exchange_u64(void* addr, uint64_t value)
+	{
+		return __atomic_exchange_n((volatile uint64_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint32_t emscripten_atomic_cas_u32(void* addr, uint32_t expected, uint32_t desired)
+	{
+		__atomic_compare_exchange_n(
+				(volatile uint32_t*)addr, &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+
+		return expected;
+	}
+
+	GDE_EXPORT uint64_t emscripten_atomic_cas_u64(void* addr, uint64_t expected, uint64_t desired)
+	{
+		__atomic_compare_exchange_n(
+				(volatile uint64_t*)addr, &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+
+		return expected;
+	}
+
+	GDE_EXPORT uint32_t emscripten_atomic_add_u32(void* addr, uint32_t value)
+	{
+		return __atomic_fetch_add((volatile uint32_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint64_t emscripten_atomic_add_u64(void* addr, uint64_t value)
+	{
+		return __atomic_fetch_add((volatile uint64_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint32_t emscripten_atomic_sub_u32(void* addr, uint32_t value)
+	{
+		return __atomic_fetch_sub((volatile uint32_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint64_t emscripten_atomic_sub_u64(void* addr, uint64_t value)
+	{
+		return __atomic_fetch_sub((volatile uint64_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint32_t emscripten_atomic_and_u32(void* addr, uint32_t value)
+	{
+		return __atomic_fetch_and((volatile uint32_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT uint32_t emscripten_atomic_or_u32(void* addr, uint32_t value)
+	{
+		return __atomic_fetch_or((volatile uint32_t*)addr, value, __ATOMIC_SEQ_CST);
+	}
+
+	GDE_EXPORT void emscripten_atomic_fence() { __atomic_thread_fence(__ATOMIC_SEQ_CST); }
+}
+#endif

--- a/addons/Wwise/native/src/scene/ak_bank.cpp
+++ b/addons/Wwise/native/src/scene/ak_bank.cpp
@@ -2,6 +2,9 @@
 
 void AkBank::_bind_methods()
 {
+	ClassDB::bind_method(D_METHOD("_on_load_async_completed", "bank_id", "result"), &AkBank::_on_load_async_completed);
+	ClassDB::bind_method(
+			D_METHOD("_on_unload_async_completed", "bank_id", "result"), &AkBank::_on_unload_async_completed);
 	ClassDB::bind_method(D_METHOD("handle_game_event", "game_event"), &AkBank::handle_game_event);
 	ClassDB::bind_method(D_METHOD("load_bank"), &AkBank::load_bank);
 	ClassDB::bind_method(D_METHOD("unload_bank"), &AkBank::unload_bank);
@@ -11,6 +14,8 @@ void AkBank::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_load_on"), &AkBank::get_load_on);
 	ClassDB::bind_method(D_METHOD("set_unload_on", "unload_on"), &AkBank::set_unload_on);
 	ClassDB::bind_method(D_METHOD("get_unload_on"), &AkBank::get_unload_on);
+	ClassDB::bind_method(D_METHOD("set_async_load", "async_load"), &AkBank::set_async_load);
+	ClassDB::bind_method(D_METHOD("get_async_load"), &AkBank::get_async_load);
 
 	ADD_PROPERTY(
 			PropertyInfo(Variant::OBJECT, "bank", PROPERTY_HINT_RESOURCE_TYPE, "WwiseBank"), "set_bank", "get_bank");
@@ -18,19 +23,32 @@ void AkBank::_bind_methods()
 			"set_load_on", "get_load_on");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "unload_on", PROPERTY_HINT_ENUM, "None,Enter Tree,Ready,Exit Tree"),
 			"set_unload_on", "get_unload_on");
-}
-
-void AkBank::_enter_tree()
-{
-	WwiseSettings* settings = WwiseSettings::get_singleton();
-
-	if (settings)
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "async_load", PROPERTY_HINT_NONE), "set_async_load", "get_async_load");
 	{
-		use_soundbank_names = settings->get_setting(settings->project_settings.use_soundbank_names, true);
+		MethodInfo mi;
+		mi.name = "bank_loaded";
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "bank_id"));
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "result"));
+		ClassDB::add_signal("AkBank", mi);
 	}
 
-	handle_game_event(AkUtils::GameEvent::GAMEEVENT_ENTER_TREE);
+	{
+		MethodInfo mi;
+		mi.name = "bank_unloaded";
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "bank_id"));
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "result"));
+		ClassDB::add_signal("AkBank", mi);
+	}
 }
+
+void AkBank::_on_load_async_completed(int p_bank_id, int p_result) { emit_signal("bank_loaded", p_bank_id, p_result); }
+
+void AkBank::_on_unload_async_completed(int p_bank_id, int p_result)
+{
+	emit_signal("bank_unloaded", p_bank_id, p_result);
+}
+
+void AkBank::_enter_tree() { handle_game_event(AkUtils::GameEvent::GAMEEVENT_ENTER_TREE); }
 
 void AkBank::_ready() { handle_game_event(AkUtils::GameEvent::GAMEEVENT_READY); }
 
@@ -60,19 +78,13 @@ void AkBank::load_bank()
 		return;
 	}
 
-	Wwise* soundengine = Wwise::get_singleton();
-
-	if (soundengine)
+	if (async_load)
 	{
-		if (use_soundbank_names)
-		{
-			bank->load();
-		}
-		else
-		{
-			uint32_t id = bank->get_id();
-			soundengine->load_bank_id(id);
-		}
+		bank->load_async(Callable(this, StringName("_on_load_async_completed")));
+	}
+	else
+	{
+		bank->load();
 	}
 }
 
@@ -86,19 +98,13 @@ void AkBank::unload_bank()
 		return;
 	}
 
-	Wwise* soundengine = Wwise::get_singleton();
-
-	if (soundengine)
+	if (async_load)
 	{
-		if (use_soundbank_names)
-		{
-			bank->unload();
-		}
-		else
-		{
-			uint32_t id = bank->get_id();
-			soundengine->unload_bank_id(id);
-		}
+		bank->unload_async(Callable(this, StringName("_on_unload_async_completed")));
+	}
+	else
+	{
+		bank->unload();
 	}
 }
 
@@ -110,10 +116,14 @@ void AkBank::set_bank(const Ref<WwiseBank>& bank)
 
 Ref<WwiseBank> AkBank::get_bank() const { return bank; }
 
-void AkBank::set_load_on(AkUtils::GameEvent load_on) { this->load_on = load_on; }
+void AkBank::set_load_on(AkUtils::GameEvent p_load_on) { load_on = p_load_on; }
 
 AkUtils::GameEvent AkBank::get_load_on() const { return load_on; }
 
-void AkBank::set_unload_on(AkUtils::GameEvent unload_on) { this->unload_on = unload_on; }
+void AkBank::set_unload_on(AkUtils::GameEvent p_unload_on) { unload_on = p_unload_on; }
 
 AkUtils::GameEvent AkBank::get_unload_on() const { return unload_on; }
+
+void AkBank::set_async_load(bool p_async_load) { async_load = p_async_load; }
+
+bool AkBank::get_async_load() const { return async_load; }

--- a/addons/Wwise/native/src/scene/ak_bank.h
+++ b/addons/Wwise/native/src/scene/ak_bank.h
@@ -20,7 +20,10 @@ private:
 	Ref<WwiseBank> bank;
 	AkUtils::GameEvent load_on = AkUtils::GameEvent::GAMEEVENT_NONE;
 	AkUtils::GameEvent unload_on = AkUtils::GameEvent::GAMEEVENT_NONE;
-	bool use_soundbank_names{ true };
+	bool async_load{ false };
+
+	void _on_load_async_completed(int p_bank_id, int p_result);
+	void _on_unload_async_completed(int p_bank_id, int p_result);
 
 public:
 	virtual void _enter_tree() override;
@@ -35,9 +38,12 @@ public:
 	void set_bank(const Ref<WwiseBank>& bank);
 	Ref<WwiseBank> get_bank() const;
 
-	void set_load_on(AkUtils::GameEvent load_on);
+	void set_load_on(AkUtils::GameEvent p_load_on);
 	AkUtils::GameEvent get_load_on() const;
 
-	void set_unload_on(AkUtils::GameEvent unload_on);
+	void set_unload_on(AkUtils::GameEvent p_unload_on);
 	AkUtils::GameEvent get_unload_on() const;
+
+	void set_async_load(bool p_async_load);
+	bool get_async_load() const;
 };

--- a/addons/Wwise/native/src/wwise_gdextension_main.cpp
+++ b/addons/Wwise/native/src/wwise_gdextension_main.cpp
@@ -70,6 +70,10 @@
 #include "gen/doc_data.gen.cpp"
 #endif
 
+#if defined(AK_EMSCRIPTEN)
+#include "platform/emscripten/ak_emscripten_atomics.cpp"
+#endif
+
 #if defined(AK_WIN) || defined(AK_MAC_OS_X)
 #include "core/waapi_gdextension.cpp"
 static Waapi* waapi_module;

--- a/addons/Wwise/native/vs2022/wwise-gdextension.vcxproj
+++ b/addons/Wwise/native/vs2022/wwise-gdextension.vcxproj
@@ -466,6 +466,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='editor|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='template_release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\src\platform\emscripten\ak_emscripten_atomics.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='editor|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\src\scene\ak_bank.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='template_debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='editor|x64'">true</ExcludedFromBuild>

--- a/addons/Wwise/native/vs2022/wwise-gdextension.vcxproj.filters
+++ b/addons/Wwise/native/vs2022/wwise-gdextension.vcxproj.filters
@@ -37,6 +37,9 @@
     <Filter Include="Source Files\editor\properties">
       <UniqueIdentifier>{19bc1cc0-af29-437f-b2d5-8cbdf8d9acd2}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\platform\emscripten">
+      <UniqueIdentifier>{8ee08ba1-47b1-48c7-90cb-90141b754d87}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\scene\ak_bank.cpp">
@@ -224,6 +227,9 @@
     </ClCompile>
     <ClCompile Include="..\src\core\wwise_logger.cpp">
       <Filter>Source Files\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\platform\emscripten\ak_emscripten_atomics.cpp">
+      <Filter>Source Files\platform\emscripten</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/addons/Wwise/native/wwise.gdextension
+++ b/addons/Wwise/native/wwise.gdextension
@@ -22,6 +22,10 @@ android.debug.arm64 = "res://addons/Wwise/native/lib/android/debug/arm64-v8a/lib
 android.release.arm64 = "res://addons/Wwise/native/lib/android/release/arm64-v8a/libWwiseAndroidPlugin.so"
 android.debug.arm32 = "res://addons/Wwise/native/lib/android/debug/armeabi-v7a/libWwiseAndroidPlugin.so"
 android.release.arm32 = "res://addons/Wwise/native/lib/android/release/armeabi-v7a/libWwiseAndroidPlugin.so"
+web.debug = "res://addons/Wwise/native/lib/web/st/template_debug/profile/libwwise.web.template_debug.profile.nothreads.wasm"
+web.release = "res://addons/Wwise/native/lib/web/st/template_release/release/libwwise.web.template_release.release.nothreads.wasm"
+web.debug.threads = "res://addons/Wwise/native/lib/web/st/template_debug/profile/libwwise.web.template_debug.profile.wasm"
+web.release.threads = "res://addons/Wwise/native/lib/web/st/template_release/release/libwwise.web.template_release.release.wasm"
 
 [icons]
 


### PR DESCRIPTION
This PR introduces experimental Web platform support to the Wwise Godot integration using Emscripten to compile WebAssembly (.wasm) targets.

The main changes are:

- Core:
   - Rewrote `AkBankManager `into a state machine that handles non-blocking load/unload requests.
   - Provided low-level atomic functions not exported by Godot.
- Web Target:
   - Added automated header generation to statically link Wwise plugins (e.g., Convolution Reverb, Reflect) for Web builds. (Dynamic linking not supported yet).
   - Added a `proxy_server_url `setting to allow remote profiling connections in browser builds.
- Node Enhancements:
   - `AkBank`: Added an `async_load` property and `bank_loaded` / `bank_unloaded` signals. 
   - `WwiseEvent`: Web target performs async bank loading and event preparation by default. Modified `post()` and `post_callback() `to automatically queue calls if the event's auto-bank is still loading asynchronously.
- CI & Editor Export Pipeline:
   - Integrated Emscripten (4.0.20) into the GitHub Actions workflow to build both "threaded" and non-threaded .wasm binaries. 
   - Updated _AkEditorExportPlugin_ to automatically copy _WwiseAudioWorklet.processor.js_ to the output directory during a Web export.
- Removed support for ID-based SoundBank names. The integration now strictly requires the Wwise project setting "Use SoundBank Names for Filenames" to be enabled.

Note on Threading: Currently, the integration is constrained to use the single-threaded Wwise libs (Emscripten_st) for both threads=yes and threads=no build targets.

**Web support is currently flagged as **experimental**.**