### PR TITLE
Migrate singletons from RefCounted to Object

### DIFF
--- a/addons/Wwise/native/src/core/wwise_logger.h
+++ b/addons/Wwise/native/src/core/wwise_logger.h
@@ -14,9 +14,9 @@ enum class WwiseLogLevel
 	VeryVerbose = 5
 };
 
-class WwiseLogger : public RefCounted
+class WwiseLogger : public Object
 {
-	GDCLASS(WwiseLogger, RefCounted);
+	GDCLASS(WwiseLogger, Object);
 
 protected:
 	static void _bind_methods() {};

--- a/addons/Wwise/native/src/core/wwise_settings.h
+++ b/addons/Wwise/native/src/core/wwise_settings.h
@@ -10,9 +10,9 @@
 
 using namespace godot;
 
-class WwiseSettings : public RefCounted
+class WwiseSettings : public Object
 {
-	GDCLASS(WwiseSettings, RefCounted);
+	GDCLASS(WwiseSettings, Object);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
RefCounted singletons are expected to become invalid or produce errors in future Godot 4.7. This change makes the code compatible with that direction and avoids relying on currently unsupported behavior. See: https://github.com/godotengine/godot/pull/119429