### PR TITLE
Update LLIO hook for 26.1 Stream Manager changes

### DIFF
--- a/addons/Wwise/native/src/core/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/core/wwise_gdextension.cpp
@@ -262,7 +262,7 @@ void Wwise::init()
 	bool use_subfolders =
 			project_settings->get_setting(project_settings->project_settings.create_subfolders_for_generated_files);
 
-	low_level_io.set_use_subfolders(use_subfolders);
+	low_level_io.use_subfolders = use_subfolders;
 
 	AkBankManager::load_init_bank();
 }
@@ -289,14 +289,14 @@ void Wwise::set_banks_path(const String& p_banks_path)
 {
 	AKASSERT(!p_banks_path.is_empty());
 
-	low_level_io.set_banks_path(p_banks_path);
+	low_level_io.banks_path = p_banks_path;
 }
 
 void Wwise::set_current_language(const String& language)
 {
 	AKASSERT(!language.is_empty());
 
-	low_level_io.set_language_folder(language);
+	low_level_io.language_folder = language;
 }
 
 bool Wwise::load_bank(const String& bank_name)
@@ -1581,6 +1581,8 @@ bool Wwise::initialize_wwise_systems()
 	AkStreamMgrSettings stream_mgr_settings;
 	AK::StreamMgr::GetDefaultSettings(stream_mgr_settings);
 
+	stream_mgr_settings.pCustomLowLevelIOHook = &low_level_io;
+
 	AkDeviceSettings device_settings;
 	AK::StreamMgr::GetDefaultDeviceSettings(device_settings);
 
@@ -1596,15 +1598,11 @@ bool Wwise::initialize_wwise_systems()
 	device_settings.uMaxCachePinnedBytes = static_cast<unsigned int>(
 			project_settings->get_setting(project_settings->advanced_settings.maximum_pinned_bytes_in_cache));
 
-	if (!ERROR_CHECK_MSG(low_level_io.init(device_settings), "Initializing Low level IO failed."))
-	{
-		return false;
-	}
-
 	AkInitSettings init_settings{};
 	AK::SoundEngine::GetDefaultInitSettings(init_settings);
 
 	init_settings.settingsStreamMgr = stream_mgr_settings;
+	init_settings.settingsStreamDevice = device_settings;
 
 #if defined(AK_ENABLE_ASSERTS)
 	init_settings.pfnAssertHook = WwiseAssertHook;
@@ -1937,8 +1935,6 @@ bool Wwise::shutdown_wwise_system()
 	}
 
 	AK::SoundEngine::Term();
-
-	low_level_io.term();
 
 	AK::MemoryMgr::Term();
 

--- a/addons/Wwise/native/src/core/wwise_gdextension.h
+++ b/addons/Wwise/native/src/core/wwise_gdextension.h
@@ -60,7 +60,7 @@ private:
 
 	static CAkLock callback_data_lock;
 
-	WwiseFileIOHandler low_level_io;
+	WwiseIOHook low_level_io;
 	static HashSet<AkGameObjectID> registered_game_objects;
 
 public:

--- a/addons/Wwise/native/src/core/wwise_io_hook.cpp
+++ b/addons/Wwise/native/src/core/wwise_io_hook.cpp
@@ -227,10 +227,11 @@ void WwiseIOHook::BatchWrite(AkUInt32 in_u_num_transfers, BatchIoTransferItem* i
 
 AKRESULT WwiseIOHook::AttachToDevice(AkDeviceID in_deviceID, const AkDeviceSettings& in_deviceSettings)
 {
-	return AKRESULT::AK_Success;
+	device_id = in_deviceID;
+	return AK_Success;
 }
 
-void WwiseIOHook::DetachFromDevice() {}
+void WwiseIOHook::DetachFromDevice() { device_id = AK_INVALID_DEVICE_ID; }
 
 AKRESULT WwiseIOHook::Close(AkFileDesc* in_file_desc)
 {
@@ -272,36 +273,3 @@ void WwiseIOHook::GetDeviceDesc(AkDeviceDesc&
 }
 
 AkUInt32 WwiseIOHook::GetDeviceData() { return 1; }
-
-AKRESULT WwiseFileIOHandler::init(const AkDeviceSettings& in_device_settings)
-{
-	if (!AK::StreamMgr::GetFileLocationResolver())
-	{
-		AK::StreamMgr::SetFileLocationResolver(this);
-	}
-
-	if (!device.init(in_device_settings))
-	{
-		return AK_Fail;
-	}
-	return AK_Success;
-}
-
-void WwiseFileIOHandler::term()
-{
-	if (AK::StreamMgr::GetFileLocationResolver() == this)
-	{
-		AK::StreamMgr::SetFileLocationResolver(nullptr);
-	}
-
-	device.term();
-}
-
-void WwiseFileIOHandler::set_banks_path(const String& banks_path) { device.banks_path = banks_path; }
-
-void WwiseFileIOHandler::set_language_folder(const String& language_folder)
-{
-	device.language_folder = language_folder;
-}
-
-void WwiseFileIOHandler::set_use_subfolders(bool p_use_subfolders) { device.use_subfolders = p_use_subfolders; }

--- a/addons/Wwise/native/src/core/wwise_io_hook.h
+++ b/addons/Wwise/native/src/core/wwise_io_hook.h
@@ -48,23 +48,3 @@ public:
 	virtual void GetDeviceDesc(AkDeviceDesc& out_device_desc) override;
 	virtual AkUInt32 GetDeviceData() override;
 };
-
-class WwiseFileIOHandler : public AK::StreamMgr::IAkFileLocationResolver
-{
-private:
-	WwiseIOHook device{};
-
-public:
-	WwiseFileIOHandler() = default;
-	~WwiseFileIOHandler() override = default;
-
-	WwiseFileIOHandler(const WwiseFileIOHandler&) = delete;
-	WwiseFileIOHandler& operator=(const WwiseFileIOHandler&) = delete;
-
-	AKRESULT init(const AkDeviceSettings& in_device_settings);
-	void term();
-
-	void set_banks_path(const String& banks_path);
-	void set_language_folder(const String& language_folder);
-	void set_use_subfolders(bool p_use_subfolders);
-};


### PR DESCRIPTION
- Removed WwiseFileIOHandler: The IAkFileLocationResolver interface is no longer required for our setup.

- Updated Stream Manager Initialization: Assigned our custom hook to AkStreamMgrSettings::pCustomLowLevelIOHook to act as the default primary device.