### PR TITLE
Fix WwiseSettings crash caused by WwiseLogger initialization order

### DIFF
--- a/addons/Wwise/native/src/core/wwise_settings.cpp
+++ b/addons/Wwise/native/src/core/wwise_settings.cpp
@@ -338,7 +338,7 @@ void WwiseSettings::remove_undefined_settings()
 
 			if (!defined_settings.has(base_name))
 			{
-				WwiseLogger::log_format("Removing obsolete setting: %s", name);
+				UtilityFunctions::print(vformat("WwiseGodot: Removing obsolete setting: %s", name));
 				project_settings->set_setting(name, Variant());
 			}
 		}


### PR DESCRIPTION
Automated backport to `wwise_v2026.1`, triggered by PR #222.