### PR TITLE
Replace Initialization Settings with new Runtime Option API

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -264,7 +264,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}${{ env.PRECISION_SUFFIX }}
-          path: addons/Wwise/native/lib
+          path: | 
+            addons/Wwise/native/lib
+            addons/Wwise/metadata
 
   upload-addon:
     runs-on: "ubuntu-22.04"
@@ -286,28 +288,37 @@ jobs:
           if [ ! -d "addons/Wwise/native/lib" ]; then
           mkdir -p addons/Wwise/native/lib
           fi
+          if [ ! -d "addons/Wwise/metadata" ]; then
+          mkdir -p addons/Wwise/metadata
+          fi
           if [ -d windows${{ env.PRECISION_SUFFIX }} ]; then
-            mv windows${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            mv windows${{ env.PRECISION_SUFFIX }}/native/lib/* addons/Wwise/native/lib/
+            mv windows${{ env.PRECISION_SUFFIX }}/metadata/* addons/Wwise/metadata/
             rm -r windows${{ env.PRECISION_SUFFIX }}
           fi
           if [ -d macos${{ env.PRECISION_SUFFIX }} ]; then
-            mv macos${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            mv macos${{ env.PRECISION_SUFFIX }}/native/lib/* addons/Wwise/native/lib/
+            mv macos${{ env.PRECISION_SUFFIX }}/metadata/* addons/Wwise/metadata/
             rm -r macos${{ env.PRECISION_SUFFIX }}
           fi
           if [ -d linux${{ env.PRECISION_SUFFIX }} ]; then
-            mv linux${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            mv linux${{ env.PRECISION_SUFFIX }}/native/lib/* addons/Wwise/native/lib/
+            mv linux${{ env.PRECISION_SUFFIX }}/metadata/* addons/Wwise/metadata/
             rm -r linux${{ env.PRECISION_SUFFIX }}
           fi
           if [ -d android-lib${{ env.PRECISION_SUFFIX }} ]; then
-            mv android-lib${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            mv android-lib${{ env.PRECISION_SUFFIX }}/native/lib/* addons/Wwise/native/lib/
+            mv android-lib${{ env.PRECISION_SUFFIX }}/metadata/* addons/Wwise/metadata/
             rm -r android-lib${{ env.PRECISION_SUFFIX }}
           fi
           if [ -d ios${{ env.PRECISION_SUFFIX }} ]; then
-            mv ios${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            mv ios${{ env.PRECISION_SUFFIX }}/native/lib/* addons/Wwise/native/lib/
+            mv ios${{ env.PRECISION_SUFFIX }}/metadata/* addons/Wwise/metadata/
             rm -r ios${{ env.PRECISION_SUFFIX }}
           fi
           if [ -d web${{ env.PRECISION_SUFFIX }} ]; then
-            mv web${{ env.PRECISION_SUFFIX }}/* addons/Wwise/native/lib/
+            mv web${{ env.PRECISION_SUFFIX }}/native/lib/* addons/Wwise/native/lib/
+            mv web${{ env.PRECISION_SUFFIX }}/metadata/* addons/Wwise/metadata/
             rm -r web${{ env.PRECISION_SUFFIX }}
           fi
 

--- a/addons/Wwise/metadata/Options.Godot.json
+++ b/addons/Wwise/metadata/Options.Godot.json
@@ -1,0 +1,130 @@
+{
+  "Version": 1,
+  "Namespaces": [
+	{
+	  "Name": "integration",
+	  "DisplayName": "Integration",
+	  "Doc": "Settings specific to the Wwise integration.",
+	  "Visibility": "Default",
+	  "Options": [
+		{
+		  "Name": "root_output_path",
+		  "DisplayName": "Root Output Path",
+		  "Visibility": "Default",
+		  "Type": "String",
+		  "Doc": "The base directory containing the Wwise generated SoundBanks.",
+		  "DefaultValue": "",
+		  "GodotHint": "Dir"
+		},
+		{
+		  "Name": "startup_language",
+		  "DisplayName": "Startup Language",
+		  "Visibility": "Default",
+		  "Type": "String",
+		  "Doc": "The default language loaded when the sound engine initializes.",
+		  "DefaultValue": "English(US)"
+		},
+		{
+		  "Name": "suspend_audio_during_focus_loss",
+		  "DisplayName": "Suspend Audio During Focus Loss",
+		  "Visibility": "Default",
+		  "Type": "Boolean",
+		  "Doc": "Automatically pause audio rendering when the game window loses focus.",
+		  "DefaultValue": false
+		},
+		{
+		  "Name": "engine_logging",
+		  "DisplayName": "Engine Logging",
+		  "Visibility": "Default",
+		  "Type": "Boolean",
+		  "Doc": "Enable routing of Wwise engine messages to the Godot console.",
+		  "DefaultValue": true
+		},
+		{
+		  "Name": "log_level",
+		  "DisplayName": "Log Level",
+		  "Visibility": "Default",
+		  "Type": "Integer",
+		  "Doc": "The verbosity level of the Wwise logger.",
+		  "DefaultValue": 3,
+		  "AllowedValues": [
+			{ "Value": "None", "DisplayName": "None" },
+			{ "Value": "Error", "DisplayName": "Error" },
+			{ "Value": "Warning", "DisplayName": "Warning" },
+			{ "Value": "Log", "DisplayName": "Log" },
+			{ "Value": "Verbose", "DisplayName": "Verbose" },
+			{ "Value": "VeryVerbose", "DisplayName": "VeryVerbose" }
+		  ]
+		},
+		{
+		  "Name": "waapi_ip",
+		  "DisplayName": "WAAPI IP",
+		  "Visibility": "Default",
+		  "Type": "String",
+		  "Doc": "IP address used to connect to the Wwise Authoring API.",
+		  "DefaultValue": "127.0.0.1"
+		},
+		{
+		  "Name": "waapi_port",
+		  "DisplayName": "WAAPI Port",
+		  "Visibility": "Default",
+		  "Type": "Integer",
+		  "Doc": "Port used to connect to the Wwise Authoring API.",
+		  "DefaultValue": 8080
+		}
+	  ]
+	},
+	{
+	  "Name": "project",
+	  "DisplayName": "Project",
+	  "Doc": "Internal project configuration mappings.",
+	  "Visibility": "Default",
+	  "Options": [
+		{
+		  "Name": "windows_platform_info",
+		  "Visibility": "Hidden",
+		  "Type": "String",
+		  "DefaultValue": ""
+		},
+		{
+		  "Name": "mac_platform_info",
+		  "Visibility": "Hidden",
+		  "Type": "String",
+		  "DefaultValue": ""
+		},
+		{
+		  "Name": "linux_platform_info",
+		  "Visibility": "Hidden",
+		  "Type": "String",
+		  "DefaultValue": ""
+		},
+		{
+		  "Name": "ios_platform_info",
+		  "Visibility": "Hidden",
+		  "Type": "String",
+		  "DefaultValue": ""
+		},
+		{
+		  "Name": "android_platform_info",
+		  "Visibility": "Hidden",
+		  "Type": "String",
+		  "DefaultValue": ""
+		},
+		{
+		  "Name": "web_platform_info",
+		  "Visibility": "Hidden",
+		  "Type": "String",
+		  "DefaultValue": ""
+		},
+		{
+		  "Name": "custom_platform_name",
+		  "DisplayName": "Custom Platform Name",
+		  "Visibility": "Advanced",
+		  "Type": "String",
+		  "Doc": "Override the standard platform name mapping.",
+		  "DefaultValue": ""
+		}
+	  ]
+	}
+  ]
+}

--- a/addons/Wwise/native/SConstruct
+++ b/addons/Wwise/native/SConstruct
@@ -21,6 +21,8 @@ def print_project_info(env):
     print(f"  Target: {env.get('target', 'Not Defined')}")
     print(f"  Wwise Config: {env.get('wwise_config', 'Not Defined')}")
     print(f"  Dev Build: {env.get('dev_build', 'Not Defined')}")
+    print(f"  Debug Symbols: {env.get('debug_symbols', 'Not Defined')}")
+    print(f"  Optimizations: {env.get('optimize', 'Not Defined')}")
     print(f"  Target Path: {os.path.abspath(env.get('target_path', 'Not Defined'))}")
 
 # This is a modified version of the documentation generation function from godot-cpp in godotcpp.py.
@@ -106,7 +108,7 @@ def copy_plugins_with_skip(src_path, dst_path, file_extension, skip_plugins):
                 continue
         
             shutil.copy2(full_src_path, full_dst_path)
-            print(f"\033[32mCopied {file_name} to {dst_path}")
+            print(f"Copied {file_name} to {dst_path}")
 
 def copy_header_files_with_skip(src_path, dst_path, file_extension=".h", skip_plugins=None):
     if not os.path.exists(src_path):
@@ -131,7 +133,7 @@ def copy_header_files_with_skip(src_path, dst_path, file_extension=".h", skip_pl
             
                 os.makedirs(os.path.dirname(full_dst_path), exist_ok=True)
                 shutil.copy2(full_src_path, full_dst_path)
-                print(f"\033[32mCopied header file {file_name} to {full_dst_path}")
+                print(f"Copied header file {file_name} to {full_dst_path}")
 
 skip_plugins = [
     "SineSource",
@@ -841,6 +843,39 @@ if env["platform"] == "ios":
     print_section_header("Copying iOS Plugin Headers")
     plugin_header_src_path = os.path.join(wwise_sdk_headers_path, "AK", "Plugin")
     copy_header_files_with_skip(plugin_header_src_path, dsp_target_path, skip_plugins=skip_plugins)
+
+print_section_header("Copying Runtime Options Metadata JSON")
+
+sdk_metadata_src = os.path.join(env["wwise_sdk"], "metadata")
+
+metadata_dst = os.path.abspath("../metadata")
+os.makedirs(metadata_dst, exist_ok=True)
+
+platform_json_map = {
+    "windows": "Options.Windows.json",
+    "macos": "Options.Mac.json",
+    "linux": "Options.Linux.json",
+    "ios": "Options.iOS.json",
+    "web": "Options.Emscripten.json"
+}
+
+common_src_file = os.path.join(sdk_metadata_src, "Options.Common.json")
+if os.path.exists(common_src_file):
+    shutil.copy2(common_src_file, os.path.join(metadata_dst, "Options.Common.json"))
+    print(f"Copied common metadata: Options.Common.json to {metadata_dst}")
+else:
+    print(f"\033[31mWarning: Could not find Options.Common.json at {common_src_file}\033[0m")
+
+current_platform = env["platform"]
+if current_platform in platform_json_map:
+    target_json_name = platform_json_map[current_platform]
+    platform_src_file = os.path.join(sdk_metadata_src, target_json_name)
+    
+    if os.path.exists(platform_src_file):
+        shutil.copy2(platform_src_file, os.path.join(metadata_dst, target_json_name))
+        print(f"Copied platform metadata: {target_json_name} to {metadata_dst}")
+    else:
+        print(f"\033[33mNotice: Platform metadata file {target_json_name} not found in SDK folder.\033[0m")
 
 print_section_header("Compiling GDExtension")
 

--- a/addons/Wwise/native/android/plugin/build.gradle.kts
+++ b/addons/Wwise/native/android/plugin/build.gradle.kts
@@ -194,10 +194,25 @@ val copyAddonsToDemo by tasks.registering(Copy::class) {
     finalizedBy(copyReleaseSharedLibs)
 }
 
+val copyAndroidMetadata by tasks.registering(Copy::class) {
+    description = "Copies Wwise Android runtime metadata JSON files"
+
+    val sdkMetadataDir = "${project.findProperty("WWISE_SDK")}/metadata"
+    val dstDir = "../../../metadata"
+
+    from(sdkMetadataDir) {
+        include("Options.Common.json")
+        include("Options.Android.json")
+    }
+
+    into(dstDir)
+}
+
 tasks.named("preBuild").dependsOn(copyExportScriptsTemplate)
 
 tasks.named("assemble").configure {
     dependsOn(copyExportScriptsTemplate)
+    dependsOn(copyAndroidMetadata)
     finalizedBy(copyAddonsToDemo)
 }
 

--- a/addons/Wwise/native/build_profile_runtime.json
+++ b/addons/Wwise/native/build_profile_runtime.json
@@ -12,6 +12,7 @@
 		"CylinderShape3D",
 		"DisplayServer",
 		"Engine",
+		"JSON",
 		"Material",
 		"MeshDataTool",
 		"MeshInstance3D",

--- a/addons/Wwise/native/src/core/wwise_gdextension.cpp
+++ b/addons/Wwise/native/src/core/wwise_gdextension.cpp
@@ -2,6 +2,7 @@
 
 #if defined(AK_ANDROID)
 #include "platform/android/jni_support.cpp"
+#include <AK/SoundEngine/Platforms/Android/AkOption.Android.h>
 #endif
 
 #include <AK/Plugin/AllPluginsFactories.h>
@@ -203,7 +204,7 @@ void Wwise::init()
 
 	WwiseSettings* project_settings = WwiseSettings::get_singleton();
 
-	String root_output_path = project_settings->get_setting(project_settings->common_user_settings.root_output_path);
+	String root_output_path = project_settings->get_setting(project_settings->integration_settings.root_output_path);
 
 	Ref<WwisePlatformInfo> platform_info;
 	String platform_info_res_path;
@@ -244,12 +245,12 @@ void Wwise::init()
 	String banks_path = vformat("%s/%s/", root_output_path, banks_platform_suffix);
 	set_banks_path(banks_path);
 
-	String startup_language = project_settings->get_setting(project_settings->common_user_settings.startup_language);
+	String startup_language = project_settings->get_setting(project_settings->integration_settings.startup_language);
 	set_current_language(startup_language);
 
 #if !defined(AK_OPTIMIZED)
 	const bool engineLogging =
-			static_cast<bool>(project_settings->get_setting(project_settings->common_user_settings.engine_logging));
+			static_cast<bool>(project_settings->get_setting(project_settings->integration_settings.engine_logging));
 
 	if (engineLogging)
 	{
@@ -258,11 +259,6 @@ void Wwise::init()
 				"Setting local output to ErrorLevel_All failed.");
 	}
 #endif
-
-	bool use_subfolders =
-			project_settings->get_setting(project_settings->project_settings.create_subfolders_for_generated_files);
-
-	low_level_io.use_subfolders = use_subfolders;
 
 	AkBankManager::load_init_bank();
 }
@@ -1576,349 +1572,40 @@ void Wwise::post_unregister_game_object(AKRESULT p_result, const Node* p_node, A
 bool Wwise::initialize_wwise_systems()
 {
 	WwiseSettings* project_settings = WwiseSettings::get_singleton();
+	project_settings->apply_options_to_wwise();
 
-	AkMemSettings mem_settings;
-	AK::MemoryMgr::GetDefaultSettings(mem_settings);
-	if (!ERROR_CHECK_MSG(AK::MemoryMgr::Init(&mem_settings), "Memory manager initialization failed."))
+	AK::Option::SetP(AkOption_StreamMgr::AkOption_StreamMgr_LowLevelIOHook, &low_level_io);
+
+	if (!ERROR_CHECK_MSG(AK::MemoryMgr::Init(), "Memory manager initialization failed."))
 	{
 		return false;
 	}
 
-	AkStreamMgrSettings stream_mgr_settings;
-	AK::StreamMgr::GetDefaultSettings(stream_mgr_settings);
-
-	stream_mgr_settings.pCustomLowLevelIOHook = &low_level_io;
-
-	AkDeviceSettings device_settings;
-	AK::StreamMgr::GetDefaultDeviceSettings(device_settings);
-
-	device_settings.bUseStreamCache =
-			static_cast<bool>(project_settings->get_setting(project_settings->advanced_settings.use_stream_cache));
-
-	device_settings.fTargetAutoStmBufferLength = static_cast<float>(
-			project_settings->get_setting(project_settings->advanced_settings.target_auto_stream_buffer_length_ms));
-
-	device_settings.uIOMemorySize = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->advanced_settings.io_memory_size));
-
-	device_settings.uMaxCachePinnedBytes = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->advanced_settings.maximum_pinned_bytes_in_cache));
-
-	AkInitSettings init_settings{};
-	AK::SoundEngine::GetDefaultInitSettings(init_settings);
-
-	init_settings.settingsStreamMgr = stream_mgr_settings;
-	init_settings.settingsStreamDevice = device_settings;
-
 #if defined(AK_ENABLE_ASSERTS)
-	init_settings.pfnAssertHook = WwiseAssertHook;
+	se_hooks.pfAssertHook = WwiseAssertHook;
 #endif
-
-	init_settings.bDebugOutOfRangeCheckEnabled = static_cast<bool>(
-			project_settings->get_setting(project_settings->advanced_settings.debug_out_of_range_check_enabled));
-
-	init_settings.bEnableGameSyncPreparation = static_cast<bool>(
-			project_settings->get_setting(project_settings->advanced_settings.enable_game_sync_preparation));
-
-	init_settings.fStreamingLookAheadRatio = static_cast<float>(
-			project_settings->get_setting(project_settings->common_user_settings.streaming_look_ahead_ratio));
-
-	init_settings.fDebugOutOfRangeLimit = static_cast<float>(
-			project_settings->get_setting(project_settings->advanced_settings.debug_out_of_range_limit));
-
-	String audioDeviceShareSet =
-			project_settings->get_setting(project_settings->common_user_settings.main_output.audio_device_shareset);
-	init_settings.settingsMainOutput.audioDeviceShareset =
-			AK::SoundEngine::GetIDFromString(audioDeviceShareSet.utf8().get_data());
-
-	const unsigned int channelConfigType = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.main_output.channel_config_type));
-
-	const unsigned int numChannels = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.main_output.number_of_channels));
-
-	if (channelConfigType == AK_ChannelConfigType_Anonymous)
-	{
-		init_settings.settingsMainOutput.channelConfig.SetAnonymous(numChannels);
-	}
-	else if (channelConfigType == AK_ChannelConfigType_Standard)
-	{
-		init_settings.settingsMainOutput.channelConfig.SetStandard(numChannels);
-	}
-	else if (channelConfigType == AK_ChannelConfigType_Ambisonic)
-	{
-		init_settings.settingsMainOutput.channelConfig.SetAmbisonic(numChannels);
-	}
-	else
-	{
-		AKASSERT(false);
-	}
-
-	init_settings.settingsMainOutput.idDevice = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.main_output.device_id));
-
-	init_settings.settingsMainOutput.ePanningRule = static_cast<AkPanningRule>(static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.main_output.panning_rule)));
-
-	init_settings.uCommandQueueSize = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.command_queue_size));
-
-	init_settings.uContinuousPlaybackLookAhead = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->advanced_settings.continuous_playback_look_ahead));
-
-	init_settings.uMaxHardwareTimeoutMs = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->advanced_settings.maximum_hardware_timeout_ms));
-
-	init_settings.uMaxNumPaths = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.maximum_number_of_positioning_paths));
-
-	init_settings.uMonitorQueuePoolSize = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->advanced_settings.monitor_queue_pool_size));
-
-	const unsigned int num_samples_per_frame_enum = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.samples_per_frame));
-
-	switch (num_samples_per_frame_enum)
-	{
-		case SamplesPerFrame::SAMPLES_256:
-			init_settings.uNumSamplesPerFrame = 256;
-			break;
-		case SamplesPerFrame::SAMPLES_512:
-			init_settings.uNumSamplesPerFrame = 512;
-			break;
-		case SamplesPerFrame::SAMPLES_1024:
-			init_settings.uNumSamplesPerFrame = 1024;
-			break;
-		case SamplesPerFrame::SAMPLES_2048:
-			init_settings.uNumSamplesPerFrame = 2048;
-			break;
-		default:
-			AKASSERT(false);
-			break;
-	}
-
-	init_settings.fGameUnitsToMeters = static_cast<float>(
-			project_settings->get_setting(project_settings->common_user_settings.game_units_to_meters));
-
-	init_settings.eFloorPlane = AkFloorPlane_Default;
-
-	AkPlatformInitSettings platform_init_settings;
-	AK::SoundEngine::GetDefaultPlatformInitSettings(platform_init_settings);
-
-	// Common platform settings
-	const unsigned int num_refills_in_voice_enum = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.number_of_refills_in_voice));
-
-	switch (num_refills_in_voice_enum)
-	{
-		case NumRefillsInVoice::REFILLS_2:
-			platform_init_settings.uNumRefillsInVoice = 2;
-			break;
-		case NumRefillsInVoice::REFILLS_4:
-			platform_init_settings.uNumRefillsInVoice = 4;
-			break;
-		default:
-			AKASSERT(false);
-			break;
-	}
-
-	const unsigned int samplerate_enum = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->common_user_settings.sample_rate));
-
-	switch (samplerate_enum)
-	{
-		case SampleRate::RATE_16000:
-			platform_init_settings.uSampleRate = 16000;
-			break;
-		case SampleRate::RATE_24000:
-			platform_init_settings.uSampleRate = 24000;
-			break;
-		case SampleRate::RATE_32000:
-			platform_init_settings.uSampleRate = 32000;
-			break;
-		case SampleRate::RATE_44100:
-			platform_init_settings.uSampleRate = 44100;
-			break;
-		case SampleRate::RATE_48000:
-			platform_init_settings.uSampleRate = 48000;
-			break;
-		default:
-			AKASSERT(false);
-			break;
-	}
+	AK::Option::SetP(AkOption_SoundEngine::AkOption_SoundEngine_Hooks, &se_hooks);
 
 #if defined(TOOLS_ENABLED)
 	String dsp_path = AkEditorSettings::get_editor_plugins_path();
-	AkOSChar* dll_path;
-	CONVERT_CHAR_TO_OSCHAR(ProjectSettings::get_singleton()->globalize_path(dsp_path).utf8().get_data(), dll_path);
-	init_settings.szPluginDLLPath = dll_path;
+	AK::Option::SetS(AkOption_SoundEngine::AkOption_SoundEngine_PluginPath,
+			ProjectSettings::get_singleton()->globalize_path(dsp_path).utf8().get_data());
 #endif
-
 	// Platform-specific settings
 #ifdef AK_WIN
-	platform_init_settings.uMaxSystemAudioObjects = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.windows_max_system_audio_objects));
-
 #elif defined(AK_MAC_OS_X)
-	platform_init_settings.eAudioAPI = static_cast<AkAudioAPIMac>(static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.macos_audio_api)));
-
 #elif defined(AK_IOS)
-	platform_init_settings.eAudioAPI = static_cast<AkAudioAPIiOS>(static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.ios_audio_api)));
-
-	const unsigned int session_category_enum = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.ios_audio_session_category));
-
-	platform_init_settings.audioSession.eCategory = static_cast<AkAudioSessionCategory>(session_category_enum);
-
-	const unsigned int session_category_flags = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.ios_audio_session_category_options));
-
-	platform_init_settings.audioSession.eCategoryOptions =
-			static_cast<AkAudioSessionCategoryOptions>(session_category_flags);
-
-	const unsigned int audio_session_mode_enum = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.ios_audio_session_mode));
-
-	platform_init_settings.audioSession.eMode = static_cast<AkAudioSessionMode>(audio_session_mode_enum);
-
 #elif defined(AK_ANDROID)
-	AkAudioAPIAndroid android_api_flag = AkAudioAPI_Default;
-
-	int selected_api_index =
-			static_cast<int>(project_settings->get_setting(project_settings->platform_settings.android_audio_api));
-
-	switch (selected_api_index)
-	{
-		case 0:
-			android_api_flag = AkAudioAPI_AAudio;
-			break;
-		case 1:
-			android_api_flag = AkAudioAPI_OpenSL_ES;
-			break;
-		case 2:
-			android_api_flag = AkAudioAPI_DolbyAtmos;
-			break;
-		case 3:
-			android_api_flag = AkAudioAPI_AndroidSpatializer;
-			break;
-		case 4:
-			android_api_flag = AkAudioAPI_Default;
-			break;
-		default:
-			android_api_flag = AkAudioAPI_Default;
-			break;
-	}
-
-	platform_init_settings.eAudioAPI = android_api_flag;
-
-	platform_init_settings.pJavaVM = JNISupport::getJavaVM();
-	platform_init_settings.jActivity = JNISupport::getActivity();
-
-	AkOSChar* dll_path;
-	CONVERT_CHAR_TO_OSCHAR(JNISupport::getPluginsDir().c_str(), dll_path);
-	init_settings.szPluginDLLPath = dll_path;
-
-	// todo(afama): Expose setting
-	platform_init_settings.eAudioPath = AkAudioPath_LowLatency;
-
+	AK::Option::SetP(AkOption_Android::AkOption_Android_JavaVM, JNISupport::getJavaVM());
+	AK::Option::SetP(AkOption_Android::AkOption_Android_ActivityReference, JNISupport::getActivity());
+	AK::Option::SetS(AkOption_SoundEngine::AkOption_SoundEngine_PluginPath, JNISupport::getPluginsDir().c_str());
 #elif defined(AK_LINUX)
-	platform_init_settings.eAudioAPI = static_cast<AkAudioAPILinux>(static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->platform_settings.linux_audio_api)));
 #elif defined(AK_EMSCRIPTEN)
-	platform_init_settings.bVerboseSystemOutput =
-			project_settings->get_setting(project_settings->platform_settings.web_verbose_system_output);
 #else
 #error "Platform not supported"
 #endif
 
-	AkAcousticsInitSettings acoustics_init_settings;
-
-	acoustics_init_settings.uMaxSoundPropagationDepth = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_sound_propagation_depth));
-
-	acoustics_init_settings.fMovementThreshold = static_cast<AkReal32>(
-			project_settings->get_setting(project_settings->acoustics_settings.movement_threshold));
-
-	acoustics_init_settings.uNumberOfPrimaryRays = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.number_of_primary_rays));
-
-	acoustics_init_settings.uMaxReflectionOrder = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_reflection_order));
-
-	acoustics_init_settings.uMaxDiffractionOrder = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_diffraction_order));
-
-	acoustics_init_settings.uMaxDiffractionPaths = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_diffraction_paths));
-
-	acoustics_init_settings.uMaxGlobalReflectionPaths = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_global_reflection_paths));
-
-	acoustics_init_settings.uMaxEmitterRoomAuxSends = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_emitter_room_aux_sends));
-
-	acoustics_init_settings.uDiffractionOnReflectionsOrder = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.diffraction_on_reflections_order));
-
-	acoustics_init_settings.fMaxDiffractionAngleDegrees = static_cast<AkReal32>(
-			project_settings->get_setting(project_settings->acoustics_settings.max_diffraction_angle_degrees));
-
-	acoustics_init_settings.fMaxPathLength =
-			static_cast<AkReal32>(project_settings->get_setting(project_settings->acoustics_settings.max_path_length));
-
-	acoustics_init_settings.fCPULimitPercentage = static_cast<AkReal32>(
-			project_settings->get_setting(project_settings->acoustics_settings.cpu_limit_percentage));
-
-	acoustics_init_settings.fSmoothingConstantMs = static_cast<AkReal32>(
-			project_settings->get_setting(project_settings->acoustics_settings.smoothing_constant_ms));
-
-	acoustics_init_settings.uLoadBalancingSpread = static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.load_balancing_spread));
-
-	acoustics_init_settings.bEnableGeometricDiffractionAndTransmission =
-			static_cast<bool>(project_settings->get_setting(
-					project_settings->acoustics_settings.enable_geometric_diffraction_and_transmission));
-
-	acoustics_init_settings.bCalcEmitterVirtualPosition = static_cast<bool>(
-			project_settings->get_setting(project_settings->acoustics_settings.calc_emitter_virtual_position));
-
-	acoustics_init_settings.eTransmissionOperation = (AkTransmissionOperation) static_cast<AkUInt32>(
-			project_settings->get_setting(project_settings->acoustics_settings.transmission_operation));
-
-	acoustics_init_settings.bEnableAcoustics = true;
-	init_settings.settingsAcoustics = acoustics_init_settings;
-
-#ifndef AK_OPTIMIZED
-	AkCommSettings comm_settings{};
-	AK::Comm::GetDefaultInitSettings(comm_settings);
-
-	comm_settings.bInitSystemLib = static_cast<bool>(
-			project_settings->get_setting(project_settings->communication_settings.initialize_system_comms));
-
-	comm_settings.ports.uCommand = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->communication_settings.command_port));
-
-	comm_settings.ports.uDiscoveryBroadcast = static_cast<unsigned int>(
-			project_settings->get_setting(project_settings->communication_settings.discovery_broadcast_port));
-
-	String network_name = project_settings->get_setting(project_settings->communication_settings.network_name);
-	AKPLATFORM::SafeStrCpy(
-			comm_settings.szAppNetworkName, network_name.utf8().get_data(), AK_COMM_SETTINGS_MAX_STRING_SIZE);
-
-#if defined(AK_EMSCRIPTEN)
-	String proxy_server_url = project_settings->get_setting(project_settings->communication_settings.proxy_server_url);
-	AKPLATFORM::SafeStrCpy(
-			comm_settings.szCommProxyServerUrl, proxy_server_url.utf8().get_data(), AK_COMM_SETTINGS_MAX_URL_SIZE);
-#endif
-
-	comm_settings.bEnableComms = true;
-	init_settings.settingsCommunications = comm_settings;
-#endif
-
-	if (!ERROR_CHECK_MSG(
-				AK::SoundEngine::Init(&init_settings, &platform_init_settings), "Sound engine initialization failed."))
+	if (!ERROR_CHECK_MSG(AK::SoundEngine::Init(), "Sound engine initialization failed."))
 
 	{
 		return false;
@@ -1929,7 +1616,6 @@ bool Wwise::initialize_wwise_systems()
 
 bool Wwise::shutdown_wwise_system()
 {
-
 	if (!ERROR_CHECK(AK::SoundEngine::UnregisterAllGameObj()))
 	{
 		return false;

--- a/addons/Wwise/native/src/core/wwise_gdextension.h
+++ b/addons/Wwise/native/src/core/wwise_gdextension.h
@@ -61,6 +61,7 @@ private:
 	static CAkLock callback_data_lock;
 
 	WwiseIOHook low_level_io;
+	AkSoundEngineHooks se_hooks{};
 	static HashSet<AkGameObjectID> registered_game_objects;
 
 public:

--- a/addons/Wwise/native/src/core/wwise_io_hook.cpp
+++ b/addons/Wwise/native/src/core/wwise_io_hook.cpp
@@ -228,6 +228,7 @@ void WwiseIOHook::BatchWrite(AkUInt32 in_u_num_transfers, BatchIoTransferItem* i
 AKRESULT WwiseIOHook::AttachToDevice(AkDeviceID in_deviceID, const AkDeviceSettings& in_deviceSettings)
 {
 	device_id = in_deviceID;
+	use_subfolders = in_deviceSettings.bUseSubfoldering;
 	return AK_Success;
 }
 

--- a/addons/Wwise/native/src/core/wwise_logger.cpp
+++ b/addons/Wwise/native/src/core/wwise_logger.cpp
@@ -23,7 +23,7 @@ void WwiseLogger::refresh_log_level()
 	if (WwiseSettings::get_singleton())
 	{
 		int level = WwiseSettings::get_singleton()->get_setting(
-				WwiseSettings::get_singleton()->wwise_logger_settings.log_level, (int)WwiseLogLevel::Log);
+				WwiseSettings::get_singleton()->integration_settings.log_level, (int)WwiseLogLevel::Log);
 		log_level = static_cast<WwiseLogLevel>(level);
 	}
 }

--- a/addons/Wwise/native/src/core/wwise_settings.cpp
+++ b/addons/Wwise/native/src/core/wwise_settings.cpp
@@ -11,105 +11,18 @@ WwiseSettings::WwiseSettings()
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	// Common User Settings
-	common_user_settings.root_output_path = "wwise/common_user_settings/root_output_path";
-	common_user_settings.startup_language = "wwise/common_user_settings/startup_language";
-	common_user_settings.suspend_audio_during_focus_loss = "wwise/common_user_settings/suspend_audio_during_focus_loss";
-	common_user_settings.engine_logging = "wwise/common_user_settings/engine_logging";
-	common_user_settings.maximum_number_of_positioning_paths =
-			"wwise/common_user_settings/maximum_number_of_positioning_paths";
-	common_user_settings.command_queue_size = "wwise/common_user_settings/command_queue_size";
-	common_user_settings.samples_per_frame = "wwise/common_user_settings/samples_per_frame";
-	common_user_settings.game_units_to_meters = "wwise/common_user_settings/game_units_to_meters";
-	common_user_settings.number_of_refills_in_voice = "wwise/common_user_settings/number_of_refills_in_voice";
-	common_user_settings.sample_rate = "wwise/common_user_settings/sample_rate";
-	common_user_settings.streaming_look_ahead_ratio = "wwise/common_user_settings/streaming_look_ahead_ratio";
-
-	// Main Output Settings
-	common_user_settings.main_output.audio_device_shareset =
-			"wwise/common_user_settings/main_output/audio_device_shareset";
-	common_user_settings.main_output.device_id = "wwise/common_user_settings/main_output/device_id";
-	common_user_settings.main_output.panning_rule = "wwise/common_user_settings/main_output/panning_rule";
-	common_user_settings.main_output.channel_config_type = "wwise/common_user_settings/main_output/channel_config_type";
-	common_user_settings.main_output.number_of_channels = "wwise/common_user_settings/main_output/number_of_channels";
-
-	// Spatial Audio Settings
-	acoustics_settings.max_sound_propagation_depth =
-			"wwise/common_user_settings/spatial_audio/max_sound_propagation_depth";
-	acoustics_settings.movement_threshold = "wwise/common_user_settings/spatial_audio/movement_threshold";
-	acoustics_settings.number_of_primary_rays = "wwise/common_user_settings/spatial_audio/number_of_primary_rays";
-	acoustics_settings.max_reflection_order = "wwise/common_user_settings/spatial_audio/max_reflection_order";
-	acoustics_settings.max_diffraction_order = "wwise/common_user_settings/spatial_audio/max_diffraction_order";
-	acoustics_settings.max_diffraction_paths = "wwise/common_user_settings/spatial_audio/max_diffraction_paths";
-	acoustics_settings.max_global_reflection_paths =
-			"wwise/common_user_settings/spatial_audio/max_global_reflection_paths";
-	acoustics_settings.max_emitter_room_aux_sends =
-			"wwise/common_user_settings/spatial_audio/max_emitter_room_aux_sends";
-	acoustics_settings.diffraction_on_reflections_order =
-			"wwise/common_user_settings/spatial_audio/diffraction_on_reflections_order";
-	acoustics_settings.max_diffraction_angle_degrees =
-			"wwise/common_user_settings/spatial_audio/max_diffraction_angle_degrees";
-	acoustics_settings.max_path_length = "wwise/common_user_settings/spatial_audio/max_path_length";
-	acoustics_settings.cpu_limit_percentage = "wwise/common_user_settings/spatial_audio/cpu_limit_percentage";
-	acoustics_settings.smoothing_constant_ms = "wwise/common_user_settings/spatial_audio/smoothing_constant_ms";
-	acoustics_settings.load_balancing_spread = "wwise/common_user_settings/spatial_audio/load_balancing_spread";
-	acoustics_settings.enable_geometric_diffraction_and_transmission =
-			"wwise/common_user_settings/spatial_audio/enable_geometric_diffraction_and_transmission";
-	acoustics_settings.calc_emitter_virtual_position =
-			"wwise/common_user_settings/spatial_audio/calc_emitter_virtual_position";
-	acoustics_settings.transmission_operation = "wwise/common_user_settings/spatial_audio/transmission_operation";
-
-	// Advanced Settings
-	advanced_settings.io_memory_size = "wwise/common_advanced_settings/IO_memory_size";
-	advanced_settings.target_auto_stream_buffer_length_ms =
-			"wwise/common_advanced_settings/target_auto_stream_buffer_length_ms";
-	advanced_settings.use_stream_cache = "wwise/common_advanced_settings/use_stream_cache";
-	advanced_settings.maximum_pinned_bytes_in_cache = "wwise/common_advanced_settings/maximum_pinned_bytes_in_cache";
-	advanced_settings.enable_game_sync_preparation = "wwise/common_advanced_settings/enable_game_sync_preparation";
-	advanced_settings.continuous_playback_look_ahead = "wwise/common_advanced_settings/continuous_playback_look_ahead";
-	advanced_settings.monitor_queue_pool_size = "wwise/common_advanced_settings/monitor_queue_pool_size";
-	advanced_settings.maximum_hardware_timeout_ms = "wwise/common_advanced_settings/maximum_hardware_timeout_ms";
-	advanced_settings.debug_out_of_range_check_enabled =
-			"wwise/common_advanced_settings/debug_out_of_range_check_enabled";
-	advanced_settings.debug_out_of_range_limit = "wwise/common_advanced_settings/debug_out_of_range_limit";
-
-	// Communication Settings
-	communication_settings.discovery_broadcast_port = "wwise/communication_settings/discovery_broadcast_port";
-	communication_settings.command_port = "wwise/communication_settings/command_port";
-	communication_settings.initialize_system_comms = "wwise/communication_settings/initialize_system_comms";
-	communication_settings.network_name = "wwise/communication_settings/network_name";
-	communication_settings.waapi_port = "wwise/communication_settings/waapi_port";
-	communication_settings.proxy_server_url = "wwise/communication_settings/proxy_server_url";
-
-	// Platform Settings
-	platform_settings.windows_max_system_audio_objects = "wwise/windows_advanced_settings/max_system_audio_objects";
-	platform_settings.macos_audio_api = "wwise/macos_advanced_settings/audio_API";
-	platform_settings.ios_audio_api = "wwise/ios_advanced_settings/audio_API";
-	platform_settings.ios_audio_session_category = "wwise/ios_advanced_settings/audio_session_category";
-	platform_settings.ios_audio_session_category_options = "wwise/ios_advanced_settings/audio_session_category_options";
-	platform_settings.ios_audio_session_mode = "wwise/ios_advanced_settings/audio_session_mode";
-	platform_settings.android_audio_api = "wwise/android_advanced_settings/audio_API";
-	platform_settings.linux_audio_api = "wwise/linux_advanced_settings/audio_API";
-	platform_settings.web_verbose_system_output = "wwise/web_advanced_settings/verbose_system_output";
-
-	// Project Settings
-	project_settings.create_subfolders_for_generated_files =
-			"wwise/project_settings/create_subfolders_for_generated_files";
-	project_settings.windows_platform_info = "wwise/project_settings/windows_platform_info";
-	project_settings.mac_platform_info = "wwise/project_settings/mac_platform_info";
-	project_settings.linux_platform_info = "wwise/project_settings/linux_platform_info";
-	project_settings.ios_platform_info = "wwise/project_settings/ios_platform_info";
-	project_settings.android_platform_info = "wwise/project_settings/android_platform_info";
-	project_settings.web_platform_info = "wwise/project_settings/web_platform_info";
-	project_settings.custom_platform_name = "wwise/project_settings/custom_platform_name";
-
-	// Wwise Logger Settings
-	wwise_logger_settings.log_level = "wwise/wwise_logger_settings/log_level";
-
-	add_wwise_settings();
+	load_options_from_json("res://addons/Wwise/metadata/Options.Godot.json", "");
+	load_options_from_json("res://addons/Wwise/metadata/Options.Common.json", "");
 
 	if (Engine::get_singleton()->is_editor_hint())
 	{
+		load_options_from_json("res://addons/Wwise/metadata/Options.Windows.json", "windows");
+		load_options_from_json("res://addons/Wwise/metadata/Options.Mac.json", "macos");
+		load_options_from_json("res://addons/Wwise/metadata/Options.Linux.json", "linux");
+		load_options_from_json("res://addons/Wwise/metadata/Options.Android.json", "android");
+		load_options_from_json("res://addons/Wwise/metadata/Options.iOS.json", "ios");
+		load_options_from_json("res://addons/Wwise/metadata/Options.Emscripten.json", "web");
+
 		remove_undefined_settings();
 		defined_settings.reset();
 
@@ -117,12 +30,28 @@ WwiseSettings::WwiseSettings()
 		if (error)
 		{
 			UtilityFunctions::printerr(
-					"WwiseGodot: Encountered error %d while saving Wwise Project Settings", (int)error);
+					vformat("WwiseGodot: Encountered error %d while saving Wwise Project Settings.", (int)error));
 		}
 		else
 		{
 			UtilityFunctions::print("WwiseGodot: Saved Project Settings.");
 		}
+	}
+	else
+	{
+#ifdef AK_WIN
+		load_options_from_json("res://addons/Wwise/metadata/Options.Windows.json", "windows");
+#elif defined(AK_MAC_OS_X)
+		load_options_from_json("res://addons/Wwise/metadata/Options.Mac.json", "macos");
+#elif defined(AK_LINUX)
+		load_options_from_json("res://addons/Wwise/metadata/Options.Linux.json", "linux");
+#elif defined(AK_ANDROID)
+		load_options_from_json("res://addons/Wwise/metadata/Options.Android.json", "android");
+#elif defined(AK_IOS)
+		load_options_from_json("res://addons/Wwise/metadata/Options.iOS.json", "ios");
+#elif defined(AK_EMSCRIPTEN)
+		load_options_from_json("res://addons/Wwise/metadata/Options.Emscripten.json", "web");
+#endif
 	}
 }
 
@@ -142,7 +71,7 @@ void WwiseSettings::set_setting(const String& p_name, const Variant& p_value)
 	}
 	else
 	{
-		UtilityFunctions::push_warning("Trying to set non-existing setting: %s.", p_name);
+		UtilityFunctions::push_warning(vformat("WwiseGodot: Trying to set non-existing setting: %s.", p_name));
 	}
 }
 
@@ -181,115 +110,103 @@ Variant WwiseSettings::get_setting(const StringName& p_setting, const Variant& p
 	}
 	else
 	{
-		UtilityFunctions::push_warning("Setting '%s' not found. Returning default value.", p_setting);
+		UtilityFunctions::push_warning(
+				vformat("WwiseGodot: Setting '%s' not found. Returning default value.", p_setting));
 		return p_default;
 	}
 }
 
-void WwiseSettings::add_wwise_settings()
+void WwiseSettings::set_setting_by_wwise_key(uint32_t p_key, const Variant& p_value)
 {
-	// Common User Settings
-	add_setting(common_user_settings.root_output_path, "", Variant::Type::STRING, PROPERTY_HINT_DIR, "");
-	add_setting(common_user_settings.startup_language, "English(US)", Variant::Type::STRING);
-	add_setting(common_user_settings.suspend_audio_during_focus_loss, false, Variant::Type::BOOL);
-	add_setting(common_user_settings.engine_logging, true, Variant::Type::BOOL);
-	add_setting(common_user_settings.maximum_number_of_positioning_paths, 255, Variant::Type::INT);
-	add_setting(common_user_settings.command_queue_size, 262144, Variant::Type::INT);
-	add_setting(
-			common_user_settings.samples_per_frame, 2, Variant::Type::INT, PROPERTY_HINT_ENUM, "256, 512, 1024, 2048");
-	add_setting(common_user_settings.game_units_to_meters, 1.0f, Variant::Type::FLOAT);
-	add_setting(common_user_settings.number_of_refills_in_voice, 1, Variant::Type::INT, PROPERTY_HINT_ENUM, "2, 4");
-	add_setting(common_user_settings.sample_rate, 4, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"16000, 24000, 32000, 44100, 48000");
-	add_setting(common_user_settings.streaming_look_ahead_ratio, 1.0f, Variant::Type::FLOAT, PROPERTY_HINT_RANGE,
-			"0.0, 1.0");
+	if (!wwise_key_to_godot_path.has(p_key))
+	{
+		UtilityFunctions::push_warning(vformat("WwiseGodot: Key %d not found in mapping.", p_key));
+		return;
+	}
 
-	// Spatial Audio Settings
-	add_setting(acoustics_settings.max_sound_propagation_depth, AK_MAX_SOUND_PROPAGATION_DEPTH,
-			Variant::Type::FLOAT, PROPERTY_HINT_RANGE, "0.0,8.0");
-	add_setting(acoustics_settings.movement_threshold, 0.25f, Variant::Type::FLOAT);
-	add_setting(acoustics_settings.number_of_primary_rays, 35, Variant::Type::INT);
-	add_setting(acoustics_settings.max_reflection_order, 2, Variant::Type::INT, PROPERTY_HINT_RANGE, "1,4");
-	add_setting(acoustics_settings.max_diffraction_order, 4, Variant::Type::INT, PROPERTY_HINT_RANGE, "1,8");
-	add_setting(acoustics_settings.max_diffraction_paths, 8, Variant::Type::INT);
-	add_setting(acoustics_settings.max_global_reflection_paths, 0, Variant::Type::INT);
-	add_setting(acoustics_settings.max_emitter_room_aux_sends, 3, Variant::Type::INT);
-	add_setting(acoustics_settings.diffraction_on_reflections_order, 2, Variant::Type::INT);
-	add_setting(acoustics_settings.max_diffraction_angle_degrees, 180.f, Variant::Type::FLOAT);
-	add_setting(acoustics_settings.max_path_length, 10000.0f, Variant::Type::FLOAT);
-	add_setting(
-			acoustics_settings.cpu_limit_percentage, 0.0f, Variant::Type::FLOAT, PROPERTY_HINT_RANGE, "0.0,100.0");
-	add_setting(acoustics_settings.smoothing_constant_ms, 0.0f, Variant::Type::FLOAT);
-	add_setting(acoustics_settings.load_balancing_spread, 1, Variant::Type::INT);
-	add_setting(acoustics_settings.enable_geometric_diffraction_and_transmission, true, Variant::Type::BOOL);
-	add_setting(acoustics_settings.calc_emitter_virtual_position, true, Variant::Type::BOOL);
-	add_setting(acoustics_settings.transmission_operation, AkTransmissionOperation::AkTransmissionOperation_Default,
-			Variant::Type::INT, PROPERTY_HINT_ENUM, "Add, Multiply, Max");
+	String base_setting = wwise_key_to_godot_path[p_key];
+	String platform_setting = base_setting;
 
-	// Main Output Settings
-	add_setting(common_user_settings.main_output.audio_device_shareset, "System", Variant::Type::STRING,
-			PROPERTY_HINT_NONE, "");
-	add_setting(common_user_settings.main_output.device_id, 0, Variant::Type::INT);
-	add_setting(common_user_settings.main_output.panning_rule, 0, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"Speakers, Headphones");
-	add_setting(common_user_settings.main_output.channel_config_type, 0, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"Anonymous, Standard, Ambisonics");
-	add_setting(common_user_settings.main_output.number_of_channels, 0, Variant::Type::INT);
+#ifdef AK_WIN
+	platform_setting += GODOT_WINDOWS_SETTING_POSTFIX;
+#elif defined(AK_MAC_OS_X)
+	platform_setting += GODOT_MAC_OSX_SETTING_POSTFIX;
+#elif defined(AK_IOS)
+	platform_setting += GODOT_IOS_SETTING_POSTFIX;
+#elif defined(AK_ANDROID)
+	platform_setting += GODOT_ANDROID_SETTING_POSTFIX;
+#elif defined(AK_LINUX)
+	platform_setting += GODOT_LINUX_SETTING_POSTFIX;
+#elif defined(AK_EMSCRIPTEN)
+	platform_setting += GODOT_WEB_SETTING_POSTFIX;
+#else
+#error "Platform not supported"
+#endif
 
-	// Advanced Settings
-	add_setting(advanced_settings.io_memory_size, 2097152, Variant::Type::INT);
-	add_setting(advanced_settings.target_auto_stream_buffer_length_ms, 380, Variant::Type::INT);
-	add_setting(advanced_settings.use_stream_cache, false, Variant::Type::BOOL);
-	add_setting(advanced_settings.maximum_pinned_bytes_in_cache, static_cast<uint64_t>(4294967295), Variant::Type::INT);
-	add_setting(advanced_settings.enable_game_sync_preparation, false, Variant::Type::BOOL);
-	add_setting(advanced_settings.continuous_playback_look_ahead, 1, Variant::Type::INT);
-	add_setting(advanced_settings.monitor_queue_pool_size, 1048576, Variant::Type::INT);
-	add_setting(advanced_settings.maximum_hardware_timeout_ms, 1000, Variant::Type::INT);
-	add_setting(advanced_settings.debug_out_of_range_check_enabled, false, Variant::Type::BOOL);
-	add_setting(advanced_settings.debug_out_of_range_limit, 16.0f, Variant::Type::FLOAT);
+	godot::ProjectSettings* settings = godot::ProjectSettings::get_singleton();
+	if (!settings)
+	{
+		return;
+	}
 
-	// Communication Settings
-	add_setting(communication_settings.discovery_broadcast_port, 24024, Variant::Type::INT);
-	add_setting(communication_settings.command_port, 0, Variant::Type::INT);
-	add_setting(communication_settings.initialize_system_comms, true, Variant::Type::BOOL);
-	add_setting(communication_settings.network_name, "", Variant::Type::STRING);
-	add_setting(communication_settings.waapi_port, 8080, Variant::Type::INT);
-	add_setting(communication_settings.proxy_server_url, "ws://localhost:8095/", Variant::Type::STRING);
+	if (settings->has_setting(platform_setting))
+	{
+		set_setting(platform_setting, p_value);
+	}
+	else if (settings->has_setting(base_setting))
+	{
+		set_setting(base_setting, p_value);
+	}
+	else
+	{
+		UtilityFunctions::push_warning(
+				vformat("WwiseGodot: set_setting_by_wwise_key: Setting '%s' not found.", base_setting));
+	}
+}
 
-	// Platform Settings
-	add_setting(platform_settings.windows_max_system_audio_objects, 128, Variant::Type::INT);
-	add_setting(
-			platform_settings.macos_audio_api, 3, Variant::Type::INT, PROPERTY_HINT_FLAGS, "AVAudioEngine,AudioUnit");
-	add_setting(platform_settings.ios_audio_api, 3, Variant::Type::INT, PROPERTY_HINT_FLAGS, "AVAudioEngine,AudioUnit");
-	add_setting(platform_settings.ios_audio_session_category, 0, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"Ambient, Solo Ambient, Play And Record, Playback");
-	add_setting(platform_settings.ios_audio_session_category_options, 13, Variant::Type::INT, PROPERTY_HINT_FLAGS,
-			"Mix with others, Duck others, Allow bluetooth, Default to speaker");
-	add_setting(platform_settings.ios_audio_session_mode, 0, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"Default, Voice Chat, Game Chat, Video Recording, Measurement, Movie Playback, Video Chat");
-	add_setting(platform_settings.android_audio_api, 4, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"AAudio,OPENSL_ES,DolbyAtmos,AndroidSpatializer,Default");
-	add_setting(platform_settings.linux_audio_api, 3, Variant::Type::INT, PROPERTY_HINT_FLAGS, "PulseAudio, ALSA");
-	add_setting(platform_settings.web_verbose_system_output, false, Variant::Type::BOOL);
+Variant WwiseSettings::get_setting_by_wwise_key(uint32_t p_key, const Variant& p_default_value) const
+{
+	if (!wwise_key_to_godot_path.has(p_key))
+		return p_default_value;
 
-	// Project Settings
-	add_setting(
-			project_settings.create_subfolders_for_generated_files, false, Variant::Type::BOOL, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.windows_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.mac_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.linux_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.ios_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.android_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.web_platform_info, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
-	add_setting(project_settings.custom_platform_name, "", Variant::Type::STRING, PROPERTY_HINT_NONE, "");
+	return get_setting(wwise_key_to_godot_path[p_key], p_default_value);
+}
 
-	// Wwise Logger Settings
-	add_setting(wwise_logger_settings.log_level, 3, Variant::Type::INT, PROPERTY_HINT_ENUM,
-			"None,Error,Warning,Log,Verbose,VeryVerbose");
+void WwiseSettings::apply_options_to_wwise()
+{
+	for (const KeyValue<StringName, uint32_t>& E : setting_key_map)
+	{
+		StringName godot_path = E.key;
+		uint32_t wwise_key = E.value;
+		String wwise_type = setting_type_map[godot_path];
+
+		Variant value = get_setting(godot_path);
+		AKRESULT res = AK_Success;
+
+		if (wwise_type == "Boolean" || wwise_type == "Integer" || wwise_type == "ChannelConfig")
+		{
+			res = AK::Option::SetI(wwise_key, (int64_t)value);
+		}
+		else if (wwise_type == "Real")
+		{
+			res = AK::Option::SetF(wwise_key, (double)value);
+		}
+		else if (wwise_type == "String")
+		{
+			String str_val = value;
+			res = AK::Option::SetS(wwise_key, str_val.utf8().get_data());
+		}
+
+		if (res != AK_Success)
+		{
+			UtilityFunctions::printerr(vformat("WwiseGodot: Failed to set Wwise Option for %s. AKRESULT: %s.",
+					godot_path, wwise_error_string(res)));
+		}
+	}
 }
 
 void WwiseSettings::add_setting(const StringName& name, const Variant& default_value, Variant::Type type,
-		PropertyHint hint, const StringName& hint_string)
+		PropertyHint hint, const StringName& hint_string, Visibility visibility)
 {
 	defined_settings.insert(name);
 
@@ -301,18 +218,31 @@ void WwiseSettings::add_setting(const StringName& name, const Variant& default_v
 
 	godot::ProjectSettings* project_settings = godot::ProjectSettings::get_singleton();
 
-	if (project_settings->has_setting(name))
+	if (!project_settings->has_setting(name))
 	{
-		project_settings->add_property_info(setting);
-		project_settings->set_as_basic(name, true);
-		project_settings->set_initial_value(name, default_value);
-		return;
+		project_settings->set_setting(name, default_value);
 	}
 
-	project_settings->set_setting(name, default_value);
 	project_settings->add_property_info(setting);
-	project_settings->set_as_basic(name, true);
 	project_settings->set_initial_value(name, default_value);
+
+	switch (visibility)
+	{
+		case Visibility::DEFAULT:
+			project_settings->set_as_basic(name, true);
+			project_settings->set_as_internal(name, false);
+			break;
+
+		case Visibility::ADVANCED:
+			project_settings->set_as_basic(name, false);
+			project_settings->set_as_internal(name, false);
+			break;
+
+		case Visibility::HIDDEN:
+			project_settings->set_as_basic(name, false);
+			project_settings->set_as_internal(name, true);
+			break;
+	}
 }
 
 void WwiseSettings::remove_undefined_settings()
@@ -341,6 +271,156 @@ void WwiseSettings::remove_undefined_settings()
 				UtilityFunctions::print(vformat("WwiseGodot: Removing obsolete setting: %s", name));
 				project_settings->set_setting(name, Variant());
 			}
+		}
+	}
+}
+
+void WwiseSettings::load_options_from_json(const String& p_json_path, const String& p_platform_tag)
+{
+	Ref<FileAccess> file = FileAccess::open(p_json_path, FileAccess::READ);
+	if (file.is_null())
+	{
+		UtilityFunctions::push_warning(vformat("WwiseGodot: Failed to open Wwise options JSON at: %s", p_json_path));
+		return;
+	}
+
+	String json_string = file->get_as_text();
+	Ref<JSON> json;
+	json.instantiate();
+
+	godot::Error err = json->parse(json_string);
+	if (err != OK)
+	{
+		UtilityFunctions::printerr(vformat("WwiseGodot Failed to parse JSON: %s", p_json_path));
+		return;
+	}
+
+	Dictionary root = json->get_data();
+	Array namespaces = root["Namespaces"];
+
+	for (int i = 0; i < namespaces.size(); i++)
+	{
+		Dictionary ns = namespaces[i];
+		String module_name = ns["DisplayName"];
+		module_name = module_name.to_snake_case();
+		Array options = ns["Options"];
+
+		for (int j = 0; j < options.size(); j++)
+		{
+			Dictionary opt = options[j];
+			String option_name = opt["Name"];
+			option_name = option_name.to_snake_case();
+			String wwise_type = opt["Type"];
+
+			if (wwise_type == "Pointer")
+				continue;
+
+			Variant default_val = opt.get("DefaultValue", Variant());
+			String godot_setting_path = "wwise/" + module_name + "/" + option_name;
+
+			bool has_key = opt.has("Key");
+
+			if (has_key && setting_key_map.has(godot_setting_path) && !p_platform_tag.is_empty())
+			{
+				String override_path = godot_setting_path + "." + p_platform_tag;
+				godot::ProjectSettings::get_singleton()->set_setting(override_path, default_val);
+				continue;
+			}
+
+			Variant::Type godot_type = Variant::Type::NIL;
+			PropertyHint hint = PROPERTY_HINT_NONE;
+			String hint_string = "";
+
+			if (wwise_type == "Boolean")
+			{
+				godot_type = Variant::Type::BOOL;
+			}
+			else if (wwise_type == "Integer" || wwise_type == "ChannelConfig")
+			{
+				godot_type = Variant::Type::INT;
+				default_val = (int)default_val;
+			}
+			else if (wwise_type == "Real")
+			{
+				godot_type = Variant::Type::FLOAT;
+			}
+			else if (wwise_type == "String")
+			{
+				godot_type = Variant::Type::STRING;
+
+				if (default_val.get_type() == Variant::Type::NIL)
+				{
+					continue;
+				}
+			}
+
+			if (has_key)
+			{
+				uint32_t key = opt["Key"];
+				setting_key_map[godot_setting_path] = key;
+				setting_type_map[godot_setting_path] = wwise_type;
+				wwise_key_to_godot_path[key] = godot_setting_path;
+
+				if (key == AkOption_Acoustics::AkOption_Acoustics_Enable)
+				{
+					default_val = true;
+				}
+			}
+
+			if (opt.has("AllowedValues"))
+			{
+				Array allowed_values = opt["AllowedValues"];
+				PackedStringArray enum_strings;
+				for (int k = 0; k < allowed_values.size(); k++)
+				{
+					Dictionary val_dict = allowed_values[k];
+					enum_strings.append(val_dict["Value"]);
+				}
+				hint = PROPERTY_HINT_ENUM;
+				hint_string = String(",").join(enum_strings);
+			}
+			else if (opt.has("MinValue") && opt.has("MaxValue"))
+			{
+				hint = PROPERTY_HINT_RANGE;
+
+				if (godot_type == Variant::Type::INT)
+				{
+					Variant min_val = (int)opt["MinValue"];
+					Variant max_val = (int)opt["MaxValue"];
+
+					hint_string = String(min_val) + "," + String(max_val) + "," + "1" + "," + "prefer_slider";
+				}
+				else if (godot_type == Variant::Type::FLOAT)
+				{
+					Variant min_val = opt["MinValue"];
+					Variant max_val = opt["MaxValue"];
+
+					hint_string = String(min_val) + "," + String(max_val);
+				}
+			}
+
+			if (opt.has("GodotHint"))
+			{
+				String godot_hint = opt["GodotHint"];
+				if (godot_hint == "Dir")
+				{
+					hint = PROPERTY_HINT_DIR;
+				}
+			}
+
+			String visibility_str = opt.get("Visibility", "Default");
+			Visibility visibility = Visibility::DEFAULT;
+
+			if (visibility_str == "Advanced")
+			{
+				visibility = Visibility::ADVANCED;
+			}
+			else if (visibility_str == "Hidden")
+			{
+				visibility = Visibility::HIDDEN;
+			}
+
+			add_setting(godot_setting_path, default_val, godot_type, hint, hint_string, visibility);
 		}
 	}
 }

--- a/addons/Wwise/native/src/core/wwise_settings.h
+++ b/addons/Wwise/native/src/core/wwise_settings.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "core/utils.h"
 #include <AK/Acoustics/Common/AkAcoustics.h>
 #include <AK/Acoustics/Common/AkAcousticsTypes.h>
+#include <AK/SoundEngine/Common/AkOption.h>
 #include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/json.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
@@ -18,124 +21,51 @@ protected:
 	static void _bind_methods();
 
 private:
+	enum class Visibility
+	{
+		DEFAULT,
+		ADVANCED,
+		HIDDEN
+	};
+
 	static WwiseSettings* singleton;
 	HashSet<StringName> defined_settings;
 
-	void add_wwise_settings();
+	HashMap<StringName, uint32_t> setting_key_map;
+	HashMap<StringName, String> setting_type_map;
+	HashMap<uint32_t, StringName> wwise_key_to_godot_path;
+
 	void add_setting(const StringName& name, const Variant& default_value, Variant::Type type,
-			PropertyHint hint = PROPERTY_HINT_NONE, const StringName& hint_string = "");
+			PropertyHint hint = PROPERTY_HINT_NONE, const StringName& hint_string = "",
+			Visibility visibility = Visibility::DEFAULT);
 	void remove_undefined_settings();
+	void load_options_from_json(const String& p_json_path, const String& p_platform_tag);
 
 public:
-	struct MainOutputSettings
+	struct IntegrationSettings
 	{
-		StringName audio_device_shareset;
-		StringName device_id;
-		StringName panning_rule;
-		StringName channel_config_type;
-		StringName channel_mask;
-		StringName number_of_channels;
-	};
-
-	struct CommonUserSettings
-	{
-		StringName root_output_path;
-		StringName startup_language;
-		StringName load_init_bank_at_startup;
-		StringName suspend_audio_during_focus_loss;
-		StringName engine_logging;
-		StringName maximum_number_of_positioning_paths;
-		StringName command_queue_size;
-		StringName samples_per_frame;
-		StringName game_units_to_meters;
-		StringName number_of_refills_in_voice;
-		StringName sample_rate;
-		StringName streaming_look_ahead_ratio;
-		MainOutputSettings main_output;
-	};
-
-	struct AcousticsSettings
-	{
-		StringName max_sound_propagation_depth;
-		StringName movement_threshold;
-		StringName number_of_primary_rays;
-		StringName max_reflection_order;
-		StringName max_diffraction_order;
-		StringName max_diffraction_paths;
-		StringName max_global_reflection_paths;
-		StringName max_emitter_room_aux_sends;
-		StringName diffraction_on_reflections_order;
-		StringName max_diffraction_angle_degrees;
-		StringName max_path_length;
-		StringName cpu_limit_percentage;
-		StringName smoothing_constant_ms;
-		StringName load_balancing_spread;
-		StringName enable_geometric_diffraction_and_transmission;
-		StringName calc_emitter_virtual_position;
-		StringName transmission_operation;
-	};
-
-	struct AdvancedSettings
-	{
-		StringName io_memory_size;
-		StringName target_auto_stream_buffer_length_ms;
-		StringName use_stream_cache;
-		StringName maximum_pinned_bytes_in_cache;
-		StringName enable_game_sync_preparation;
-		StringName continuous_playback_look_ahead;
-		StringName monitor_queue_pool_size;
-		StringName maximum_hardware_timeout_ms;
-		StringName debug_out_of_range_check_enabled;
-		StringName debug_out_of_range_limit;
-	};
-
-	struct CommunicationSettings
-	{
-		StringName discovery_broadcast_port;
-		StringName command_port;
-		StringName initialize_system_comms;
-		StringName network_name;
-		StringName waapi_port;
-		StringName proxy_server_url;
-	};
-
-	struct PlatformSettings
-	{
-		StringName windows_max_system_audio_objects;
-		StringName macos_audio_api;
-		StringName ios_audio_api;
-		StringName ios_audio_session_category;
-		StringName ios_audio_session_category_options;
-		StringName ios_audio_session_mode;
-		StringName android_audio_api;
-		StringName linux_audio_api;
-		StringName web_verbose_system_output;
+		StringName root_output_path = "wwise/integration/root_output_path";
+		StringName startup_language = "wwise/integration/startup_language";
+		StringName suspend_audio_during_focus_loss = "wwise/integration/suspend_audio_during_focus_loss";
+		StringName engine_logging = "wwise/integration/engine_logging";
+		StringName log_level = "wwise/integration/log_level";
+		StringName waapi_ip = "wwise/integration/waapi_ip";
+		StringName waapi_port = "wwise/integration/waapi_port";
 	};
 
 	struct ProjectSettings
 	{
-		StringName create_subfolders_for_generated_files;
-		StringName windows_platform_info;
-		StringName mac_platform_info;
-		StringName linux_platform_info;
-		StringName ios_platform_info;
-		StringName android_platform_info;
-		StringName web_platform_info;
-		StringName custom_platform_name;
+		StringName windows_platform_info = "wwise/project/windows_platform_info";
+		StringName mac_platform_info = "wwise/project/mac_platform_info";
+		StringName linux_platform_info = "wwise/project/linux_platform_info";
+		StringName ios_platform_info = "wwise/project/ios_platform_info";
+		StringName android_platform_info = "wwise/project/android_platform_info";
+		StringName web_platform_info = "wwise/project/web_platform_info";
+		StringName custom_platform_name = "wwise/project/custom_platform_name";
 	};
 
-	struct WwiseLoggerSettings
-	{
-		StringName log_level;
-	};
-
-	CommonUserSettings common_user_settings;
-	AcousticsSettings acoustics_settings;
-	AdvancedSettings advanced_settings;
-	CommunicationSettings communication_settings;
-	PlatformSettings platform_settings;
+	IntegrationSettings integration_settings;
 	ProjectSettings project_settings;
-	WwiseLoggerSettings wwise_logger_settings;
 
 	String GODOT_WINDOWS_SETTING_POSTFIX = ".windows";
 	String GODOT_MAC_OSX_SETTING_POSTFIX = ".macos";
@@ -149,4 +79,8 @@ public:
 	~WwiseSettings();
 	void set_setting(const String& p_name, const Variant& p_value);
 	Variant get_setting(const StringName& p_setting, const Variant& p_default = Variant()) const;
+	void set_setting_by_wwise_key(uint32_t p_key, const Variant& p_value);
+	Variant get_setting_by_wwise_key(uint32_t p_key, const Variant& p_default_value) const;
+
+	void apply_options_to_wwise();
 };

--- a/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.cpp
+++ b/addons/Wwise/native/src/editor/plugins/ak_editor_export_plugin.cpp
@@ -226,7 +226,7 @@ void AkEditorExportPlugin::_export_begin(
 	gdextension_config->load(AkEditorSettings::get_gdextension_config_path());
 
 	WwiseSettings* settings = WwiseSettings::get_singleton();
-	String root_output_path = settings->get_setting(settings->common_user_settings.root_output_path);
+	String root_output_path = settings->get_setting(settings->integration_settings.root_output_path);
 
 	std::map<String, StringName> platform_settings{ { "windows", settings->project_settings.windows_platform_info },
 		{ "macos", settings->project_settings.mac_platform_info },

--- a/addons/Wwise/native/src/editor/plugins/ak_soundbank_directory_watcher_plugin.cpp
+++ b/addons/Wwise/native/src/editor/plugins/ak_soundbank_directory_watcher_plugin.cpp
@@ -15,13 +15,13 @@ void AkSoundBankDirectoryWatcherPlugin::_on_timer_timeout()
 		WwiseProjectDatabase::get_singleton()->post_init_callback();
 	}
 
-	String root_output_path = settings->get_setting(settings->common_user_settings.root_output_path);
+	String root_output_path = settings->get_setting(settings->integration_settings.root_output_path);
 	if (root_output_path.is_empty())
 	{
 		if (!empty_base_path_error_was_logged)
 		{
 			WwiseLogger::warning(
-					"The 'Root Output Path' setting in Wwise's Common User Settings (found under Godot "
+					"The 'Root Output Path' setting in Wwise's Integration Settings (found under Godot "
 					"Project > "
 					"Project Settings...) is empty. SoundBanks must be generated inside your Godot project "
 					"folder. Please generate your SoundBanks within the Godot project and update the 'Root Output "
@@ -94,10 +94,10 @@ void AkSoundBankDirectoryWatcherPlugin::init_project_db(
 				p_root_directory_path, AkEditorSettings::get_platform_name(custom_platform_name));
 
 		WwiseSettings* settings = WwiseSettings::get_singleton();
-		String current_language = settings->get_setting(settings->common_user_settings.startup_language);
+		String current_language = settings->get_setting(settings->integration_settings.startup_language);
 		if (current_language.is_empty())
 		{
-			WwiseLogger::error("Startup Language property in the advanced Wwise-Godot Project "
+			WwiseLogger::error("Startup Language property in the Wwise-Godot Project Integration "
 							   "Settings is empty. Defaulting to English(US).");
 			current_language = "English(US)";
 		}

--- a/addons/Wwise/native/src/editor/plugins/wwise_browser.cpp
+++ b/addons/Wwise/native/src/editor/plugins/wwise_browser.cpp
@@ -66,8 +66,10 @@ bool WwiseBrowser::ensure_wwise_connection()
 	if (!waapi->is_client_connected())
 	{
 		auto* settings = WwiseSettings::get_singleton();
-		auto port = settings->get_setting(settings->communication_settings.waapi_port);
-		bool connection_result = waapi->connect_client("127.0.0.1", port);
+
+		auto ip = settings->get_setting(settings->integration_settings.waapi_ip);
+		auto port = settings->get_setting(settings->integration_settings.waapi_port);
+		bool connection_result = waapi->connect_client(ip, port);
 		return connection_result;
 	}
 	return true;

--- a/addons/Wwise/native/src/editor/wwise_project_database.cpp
+++ b/addons/Wwise/native/src/editor/wwise_project_database.cpp
@@ -36,8 +36,8 @@ void WwiseProjectDatabase::post_init_callback()
 
 		WwiseSettings* settings = WwiseSettings::get_singleton();
 
-		settings->set_setting(
-				settings->project_settings.create_subfolders_for_generated_files, subfolders_for_generated_files);
+		settings->set_setting_by_wwise_key(
+				AkOption_StreamMgr::AkOption_StreamMgr_UseSubfoldering, subfolders_for_generated_files);
 
 		bool use_soundbank_names = platform_data->PlatformRef.GetPlatformInfo()->Settings.bUseSoundBankNames;
 		if (!use_soundbank_names)

--- a/addons/Wwise/runtime/wwise_runtime_manager.gd
+++ b/addons/Wwise/runtime/wwise_runtime_manager.gd
@@ -3,7 +3,7 @@ extends Node
 var suspend_on_focus_loss:bool = false;
 
 func _init() -> void:
-	suspend_on_focus_loss = ProjectSettings.get_setting("wwise/common_user_settings/suspend_audio_during_focus_loss", false)
+	suspend_on_focus_loss = ProjectSettings.get_setting("wwise/integration/suspend_audio_during_focus_loss", false)
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	Wwise.init()
 


### PR DESCRIPTION
This PR replaces the deprecated initialization settings workflow with the new Wwise Runtime Option API. 

Changes include:

- Migrating Wwise initialization to use Runtime Options instead of manually populating initialization structures.
- Adding metadata-driven option loading through JSON, reducing hardcoded settings.
- Adding `apply_options_to_wwise`to set Runtime Options before engine initialization.
- Updating build and packaging scripts to include .json metadata from SDK in GDExtension builds.
- Loading platform-specific option metadata dynamically at runtime.
- Removing obsolete initialization setting code and simplifying Wwise sound engine startup.
