### PR TITLE
Simplify Game Object registration and position updates

### DIFF
--- a/addons/Wwise/native/src/core/ak_game_obj_helper.h
+++ b/addons/Wwise/native/src/core/ak_game_obj_helper.h
@@ -1,64 +1,39 @@
 #pragma once
 
 #include "core/wwise_gdextension.h"
-#include <type_traits>
 
-template <class T> class AkGameObjHelper
+class AkGameObjHelper
 {
-private:
-	static constexpr bool is_node = std::is_base_of<Node, T>::value;
-	bool is_registered = false;
-	T* game_object;
-
 public:
-	explicit AkGameObjHelper(T* node) : game_object(node) { static_assert(is_node, "T must inherit from Node"); }
-
-	bool register_game_obj()
+	static bool register_game_obj(const Node* p_game_object)
 	{
-		if (is_registered)
-		{
-			return AKRESULT::AK_Success;
-		}
-
-		if (!game_object)
-		{
-			return false;
-		}
-
-		is_registered = true;
-		return Wwise::get_singleton()->register_game_obj(game_object, game_object->get_name());
+		return Wwise::get_singleton()->register_game_obj(p_game_object, p_game_object->get_name());
 	}
 
-	bool unregister_game_obj()
+	static bool unregister_game_obj(const Node* p_game_object)
 	{
-		if (!is_registered)
-		{
-			AKRESULT::AK_Success;
-		}
-
-		is_registered = false;
-		return Wwise::get_singleton()->unregister_game_obj(game_object);
+		return Wwise::get_singleton()->unregister_game_obj(p_game_object);
 	}
 
-	void set_position();
+	static void set_position(const Node2D* p_game_object, Transform2D& p_cached_transform)
+	{
+		Transform2D current = p_game_object->get_global_transform();
 
-	bool get_is_registered() const { return is_registered; }
+		if (!current.is_equal_approx(p_cached_transform))
+		{
+			Wwise::get_singleton()->set_2d_position(p_game_object, current, 0);
+			p_cached_transform = current;
+		}
+	}
+
+	static void set_position(const Node3D* p_game_object, Transform3D& p_cached_transform)
+	{
+		Transform3D current = p_game_object->get_global_transform();
+
+		if (!current.is_equal_approx(p_cached_transform))
+		{
+			Wwise::get_singleton()->set_3d_position(p_game_object, current);
+			p_cached_transform = current;
+		}
+	}
 };
-
-template <> inline void AkGameObjHelper<Node>::set_position() {}
-
-template <> inline void AkGameObjHelper<Node2D>::set_position()
-{
-	if (game_object)
-	{
-		Wwise::get_singleton()->set_2d_position(game_object, game_object->get_global_transform(), 0);
-	}
-}
-
-template <> inline void AkGameObjHelper<Node3D>::set_position()
-{
-	if (game_object)
-	{
-		Wwise::get_singleton()->set_3d_position(game_object, game_object->get_global_transform());
-	}
-}

--- a/addons/Wwise/native/src/scene/ak_game_obj.h
+++ b/addons/Wwise/native/src/scene/ak_game_obj.h
@@ -8,9 +8,6 @@ class AkGameObj : public Node
 {
 	GDCLASS(AkGameObj, Node);
 
-private:
-	AkGameObjHelper<Node>* helper{ nullptr };
-
 protected:
 	static void _bind_methods() {};
 
@@ -19,38 +16,36 @@ protected:
 		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
-		if (p_what == NOTIFICATION_ENTER_TREE)
+		switch (p_what)
 		{
-			if (!helper)
+			case NOTIFICATION_ENTER_TREE:
 			{
-				Node* parent = get_parent();
-				if (parent)
+				game_object = get_parent();
+
+				if (!game_object)
+					return;
+
+				is_registered = AkGameObjHelper::register_game_obj(game_object);
+
+				if (!is_registered)
+					return;
+
+				set_process(false);
+				break;
+			}
+			case NOTIFICATION_PREDELETE:
+			{
+				if (is_registered && game_object)
 				{
-					helper = new AkGameObjHelper<Node>(parent);
-					if (helper->register_game_obj())
-					{
-						helper->set_position();
-					}
+					AkGameObjHelper::unregister_game_obj(game_object);
+					is_registered = false;
 				}
-			}
-		}
-
-		if (p_what == NOTIFICATION_PROCESS)
-		{
-			if (helper && helper->get_is_registered())
-			{
-				helper->set_position();
-			}
-		}
-
-		if (p_what == NOTIFICATION_PREDELETE)
-		{
-			if (helper)
-			{
-				helper->unregister_game_obj();
-				delete helper;
-				helper = nullptr;
+				break;
 			}
 		}
 	}
+
+private:
+	Node* game_object{ nullptr };
+	bool is_registered{ false };
 };

--- a/addons/Wwise/native/src/scene/ak_game_obj_2d.h
+++ b/addons/Wwise/native/src/scene/ak_game_obj_2d.h
@@ -8,9 +8,6 @@ class AkGameObj2D : public Node2D
 {
 	GDCLASS(AkGameObj2D, Node2D);
 
-private:
-	AkGameObjHelper<Node2D>* helper{ nullptr };
-
 protected:
 	static void _bind_methods() {};
 
@@ -19,40 +16,48 @@ protected:
 		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
-		if (p_what == NOTIFICATION_ENTER_TREE)
+		switch (p_what)
 		{
-			if (!helper)
+			case NOTIFICATION_ENTER_TREE:
 			{
-				Node* parent = get_parent();
-				Node2D* node_2d = Object::cast_to<Node2D>(parent);
-				if (parent && node_2d)
+				game_object = Object::cast_to<Node2D>(get_parent());
+
+				if (!game_object)
+					return;
+
+				is_registered = AkGameObjHelper::register_game_obj(game_object);
+
+				if (!is_registered)
+					return;
+
+				cached_transform = game_object->get_global_transform();
+				AkGameObjHelper::set_position(game_object, cached_transform);
+
+				set_process(true);
+				break;
+			}
+			case NOTIFICATION_PROCESS:
+			{
+				if (is_registered && game_object)
 				{
-					helper = new AkGameObjHelper<Node2D>(node_2d);
-					if (helper->register_game_obj())
-					{
-						helper->set_position();
-					}
-					set_process(true);
+					AkGameObjHelper::set_position(game_object, cached_transform);
 				}
+				break;
 			}
-		}
-
-		if (p_what == NOTIFICATION_PROCESS)
-		{
-			if (helper && helper->get_is_registered())
+			case NOTIFICATION_PREDELETE:
 			{
-				helper->set_position();
-			}
-		}
-
-		if (p_what == NOTIFICATION_PREDELETE)
-		{
-			if (helper)
-			{
-				helper->unregister_game_obj();
-				delete helper;
-				helper = nullptr;
+				if (is_registered && game_object)
+				{
+					AkGameObjHelper::unregister_game_obj(game_object);
+					is_registered = false;
+				}
+				break;
 			}
 		}
 	}
+
+private:
+	Node2D* game_object{ nullptr };
+	bool is_registered{ false };
+	Transform2D cached_transform{};
 };

--- a/addons/Wwise/native/src/scene/ak_game_obj_3d.h
+++ b/addons/Wwise/native/src/scene/ak_game_obj_3d.h
@@ -8,9 +8,6 @@ class AkGameObj3D : public Node3D
 {
 	GDCLASS(AkGameObj3D, Node3D);
 
-private:
-	AkGameObjHelper<Node3D>* helper{ nullptr };
-
 protected:
 	static void _bind_methods() {};
 
@@ -19,39 +16,48 @@ protected:
 		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
-		if (p_what == NOTIFICATION_ENTER_TREE)
+		switch (p_what)
 		{
-			if (!helper)
+			case NOTIFICATION_ENTER_TREE:
 			{
-				Node3D* parent = get_parent_node_3d();
-				if (parent)
+				game_object = get_parent_node_3d();
+
+				if (!game_object)
+					return;
+
+				is_registered = AkGameObjHelper::register_game_obj(game_object);
+
+				if (!is_registered)
+					return;
+
+				cached_transform = game_object->get_global_transform();
+				AkGameObjHelper::set_position(game_object, cached_transform);
+
+				set_process(true);
+				break;
+			}
+			case NOTIFICATION_PROCESS:
+			{
+				if (is_registered && game_object)
 				{
-					helper = new AkGameObjHelper<Node3D>(parent);
-					if (helper->register_game_obj())
-					{
-						helper->set_position();
-					}
-					set_process(true);
+					AkGameObjHelper::set_position(game_object, cached_transform);
 				}
+				break;
 			}
-		}
-
-		if (p_what == NOTIFICATION_PROCESS)
-		{
-			if (helper && helper->get_is_registered())
+			case NOTIFICATION_PREDELETE:
 			{
-				helper->set_position();
-			}
-		}
-
-		if (p_what == NOTIFICATION_PREDELETE)
-		{
-			if (helper)
-			{
-				helper->unregister_game_obj();
-				delete helper;
-				helper = nullptr;
+				if (is_registered && game_object)
+				{
+					AkGameObjHelper::unregister_game_obj(game_object);
+					is_registered = false;
+				}
+				break;
 			}
 		}
 	}
+
+private:
+	Node3D* game_object{ nullptr };
+	bool is_registered{ false };
+	Transform3D cached_transform{};
 };


### PR DESCRIPTION
Replace the old templated AkGameObjHelper<T> with a single static utility class, remove per‑node helper allocations, and streamline registration and position‑update logic in AkGameObj, AkGameObj2D, and AkGameObj3D. We cache node transforms to prevent unnecessary position API calls/updates to Wwise.