### PR TITLE
Fix initial Wwise position not being set during game object registration

### DIFF
--- a/addons/Wwise/native/src/scene/ak_game_obj_2d.h
+++ b/addons/Wwise/native/src/scene/ak_game_obj_2d.h
@@ -30,7 +30,6 @@ protected:
 				if (!is_registered)
 					return;
 
-				cached_transform = game_object->get_global_transform();
 				AkGameObjHelper::set_position(game_object, cached_transform);
 
 				set_process(true);

--- a/addons/Wwise/native/src/scene/ak_game_obj_3d.h
+++ b/addons/Wwise/native/src/scene/ak_game_obj_3d.h
@@ -30,7 +30,6 @@ protected:
 				if (!is_registered)
 					return;
 
-				cached_transform = game_object->get_global_transform();
 				AkGameObjHelper::set_position(game_object, cached_transform);
 
 				set_process(true);


### PR DESCRIPTION
Automated backport to `wwise_v2024.1`, triggered by PR #232.